### PR TITLE
Update docmaps-context.jsonld

### DIFF
--- a/docmaps-context.jsonld
+++ b/docmaps-context.jsonld
@@ -39,7 +39,7 @@
         "person": "foaf:Person",
         "publisher": {
             "@id": "dcterms:publisher",
-            "@type": "foaf:organization"
+            "@type": "@id"
         },
         "logo": "foaf:logo",
         "homepage": "foaf:homepage",


### PR DESCRIPTION
Use @type: @id for all objects

This enables cleaner IRI compaction in json-ld usages.