### PR TITLE
Add datatype constraints for URL and Date types

### DIFF
--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -18,6 +18,9 @@
     "@rdfjs/serializer-jsonld-ext": "~4.0.0",
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.20",
+    "io-ts-types": "^0.5.19",
+    "monocle-ts": "^2.3.13",
+    "newtype-ts": "^0.3.5",
     "readable-stream": "^3.6.2"
   },
   "devDependencies": {

--- a/packages/ts-sdk/pnpm-lock.yaml
+++ b/packages/ts-sdk/pnpm-lock.yaml
@@ -22,6 +22,9 @@ specifiers:
   eslint-plugin-prettier: ^4.2.1
   fp-ts: ^2.13.1
   io-ts: ^2.2.20
+  io-ts-types: ^0.5.19
+  monocle-ts: ^2.3.13
+  newtype-ts: ^0.3.5
   prettier: ^2.8.6
   rdf-ext: ^2.2.0
   readable-stream: ^3.6.2
@@ -32,6 +35,9 @@ dependencies:
   '@rdfjs/serializer-jsonld-ext': 4.0.0
   fp-ts: 2.13.1
   io-ts: 2.2.20_fp-ts@2.13.1
+  io-ts-types: 0.5.19_3r4zs434vtthvwddf63cdxp364
+  monocle-ts: 2.3.13_fp-ts@2.13.1
+  newtype-ts: 0.3.5_y4ecnzjsatnzoei5elwf4wjeqa
   readable-stream: 3.6.2
 
 devDependencies:
@@ -1437,6 +1443,20 @@ packages:
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  /io-ts-types/0.5.19_3r4zs434vtthvwddf63cdxp364:
+    resolution: {integrity: sha512-kQOYYDZG5vKre+INIDZbLeDJe+oM+4zLpUkjXyTMyUfoCpjJNyi29ZLkuEAwcPufaYo3yu/BsemZtbdD+NtRfQ==}
+    peerDependencies:
+      fp-ts: ^2.0.0
+      io-ts: ^2.0.0
+      monocle-ts: ^2.0.0
+      newtype-ts: ^0.3.2
+    dependencies:
+      fp-ts: 2.13.1
+      io-ts: 2.2.20_fp-ts@2.13.1
+      monocle-ts: 2.3.13_fp-ts@2.13.1
+      newtype-ts: 0.3.5_y4ecnzjsatnzoei5elwf4wjeqa
+    dev: false
+
   /io-ts/2.2.20_fp-ts@2.13.1:
     resolution: {integrity: sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==}
     peerDependencies:
@@ -1688,6 +1708,14 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /monocle-ts/2.3.13_fp-ts@2.13.1:
+    resolution: {integrity: sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==}
+    peerDependencies:
+      fp-ts: ^2.5.0
+    dependencies:
+      fp-ts: 2.13.1
+    dev: false
+
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -1711,6 +1739,16 @@ packages:
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
+
+  /newtype-ts/0.3.5_y4ecnzjsatnzoei5elwf4wjeqa:
+    resolution: {integrity: sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==}
+    peerDependencies:
+      fp-ts: ^2.0.0
+      monocle-ts: ^2.0.0
+    dependencies:
+      fp-ts: 2.13.1
+      monocle-ts: 2.3.13_fp-ts@2.13.1
+    dev: false
 
   /node-domexception/1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}

--- a/packages/ts-sdk/src/test/typed_graph.test.ts
+++ b/packages/ts-sdk/src/test/typed_graph.test.ts
@@ -12,13 +12,16 @@ test('Graph Extraction of a Manifestation', async (t) => {
   })) as DocmapsTypes.DocmapManifestationT
 
   t.is(mf.id, 'https://w3id.org/docmaps/examples/manifestation')
-  t.is(mf.service, 'https://w3id.org/docmaps/examples/manifestation#HOMEPAGE')
+  t.is(mf.service?.hostname, 'w3id.org')
+  t.is(mf.service?.pathname, '/docmaps/examples/manifestation')
+  t.is(mf.service?.hash, '#HOMEPAGE')
+  t.is(mf.service?.protocol, 'https:')
 
   // TODO: note how the `url` key in the jsonld context has a @type key, and therefore
   // ALL values for this must have @type specified as `xsd:anyURI` to be safely
   // parsed by `jsonld.js`. Without type specification in the data, compaction/framing
   // algorithm will use the CURIE instead of the term.
-  t.is(mf.url, 'https://w3id.org/docmaps/examples/manifestation#URL')
+  t.is(mf.url?.toString(), 'https://w3id.org/docmaps/examples/manifestation#URL')
 })
 
 test('Parsing JSONLD from concrete elife examples', async (t) => {
@@ -35,7 +38,7 @@ test('Parsing JSONLD from concrete embo examples', async (t) => {
 
   t.is(dm_embo.id, 'https://eeb.embo.org/api/v2/docmap/10.1101/2021.03.24.436774')
   t.is(dm_embo.publisher.name, 'review commons')
-  t.is(dm_embo.publisher.url, 'https://reviewcommons.org')
+  t.is(dm_embo.publisher.url?.toString(), 'https://reviewcommons.org/')
   if (!dm_embo.steps) {
     throw 'steps did not parse' // must interrupt flow for type safety later
   }

--- a/packages/ts-sdk/src/test/typed_graph.test.ts
+++ b/packages/ts-sdk/src/test/typed_graph.test.ts
@@ -31,12 +31,15 @@ test('Parsing JSONLD from concrete elife examples', async (t) => {
     dm_elife.id,
     'https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698',
   )
+
+  t.deepEqual(dm_elife.updated, new Date('2022-11-28T11:30:05+00:00'))
 })
 
 test('Parsing JSONLD from concrete embo examples', async (t) => {
   const dm_embo = g.parseJsonld(FromRootExamples.embo_01_jsonld) as DocmapsTypes.DocmapT
 
   t.is(dm_embo.id, 'https://eeb.embo.org/api/v2/docmap/10.1101/2021.03.24.436774')
+  t.deepEqual(dm_embo.created, new Date('2023-02-13T05:43:49.289Z'))
   t.is(dm_embo.publisher.name, 'review commons')
   t.is(dm_embo.publisher.url?.toString(), 'https://reviewcommons.org/')
   if (!dm_embo.steps) {

--- a/packages/ts-sdk/src/test/util.test.ts
+++ b/packages/ts-sdk/src/test/util.test.ts
@@ -1,0 +1,51 @@
+import test from 'ava'
+import { UrlFromString } from '../util'
+import { isRight, Either } from 'fp-ts/lib/Either'
+
+function rightAnd<T>(e: Either<unknown, T>, validation: (res: T) => void) {
+  if (isRight(e)) {
+    validation(e.right)
+    return true
+  } else {
+    return false
+  }
+}
+
+test('UrlFromString success cases', (t) => {
+  const url1 = UrlFromString.decode('https://docmaps.knowledgefutures.org')
+  t.true(
+    rightAnd(url1, (u) => {
+      t.is(u.host, 'docmaps.knowledgefutures.org')
+      t.is(u.protocol, 'https:')
+    }),
+  )
+
+  const url2 = UrlFromString.decode('file:///tmp/some-file.txt')
+  t.true(
+    rightAnd(url2, (u) => {
+      t.is(u.pathname, '/tmp/some-file.txt')
+      t.is(u.protocol, 'file:')
+    }),
+  )
+
+  const url3 = UrlFromString.decode('http://localhost:8080/?someQuery=true')
+  t.true(
+    rightAnd(url3, (u) => {
+      t.is(u.hostname, 'localhost')
+      t.is(u.protocol, 'http:')
+      t.is(u.port, '8080')
+      t.is(u.search, '?someQuery=true')
+    }),
+  )
+})
+
+test('UrlFromString failure cases', (t) => {
+  const url1 = UrlFromString.decode('NOT_A_URL')
+  t.false( isRight(UrlFromString.decode(url1)))
+
+  const url2 = UrlFromString.decode(409)
+  t.false( isRight(UrlFromString.decode(url1)))
+
+  const url3 = UrlFromString.decode({})
+  t.false( isRight(UrlFromString.decode(url1)))
+})

--- a/packages/ts-sdk/src/test/util.test.ts
+++ b/packages/ts-sdk/src/test/util.test.ts
@@ -41,11 +41,11 @@ test('UrlFromString success cases', (t) => {
 
 test('UrlFromString failure cases', (t) => {
   const url1 = UrlFromString.decode('NOT_A_URL')
-  t.false( isRight(UrlFromString.decode(url1)))
+  t.false(isRight(UrlFromString.decode(url1)))
 
   const url2 = UrlFromString.decode(409)
-  t.false( isRight(UrlFromString.decode(url1)))
+  t.false(isRight(UrlFromString.decode(url2)))
 
   const url3 = UrlFromString.decode({})
-  t.false( isRight(UrlFromString.decode(url1)))
+  t.false(isRight(UrlFromString.decode(url3)))
 })

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts'
+import { DateFromISOString } from 'io-ts-types'
 import { UrlFromString } from './util'
 
 function arrayOrOneOf(literalStrings: string[]) {
@@ -86,7 +87,7 @@ export const DocmapThing = t.intersection([
   t.partial({
     // TODO use DateFromString for better parsing:
     //    https://github.com/gcanti/io-ts/blob/dedb64e05328417ecd3d87e00008d9e72130374a/index.md#custom-types
-    published: t.string,
+    published: DateFromISOString,
     id: t.string,
     doi: t.string,
     type: t.union([t.array(t.string), t.string]), // TODO this Type can be more specific ('web-page', 'preprint', etc)
@@ -136,12 +137,12 @@ export const Docmap = t.intersection([
     ]),
     publisher: DocmapPublisher,
     // TODO: required contents of these date strings,
-    created: t.string,
+    created: DateFromISOString,
   }),
   t.partial({
     steps: t.record(t.string, DocmapStep),
     'first-step': t.string,
-    updated: t.string,
+    updated: DateFromISOString,
   }),
 ])
 

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts'
+import { UrlFromString } from './util'
 
 function arrayOrOneOf(literalStrings: string[]) {
   const [one, two, ...r] = literalStrings
@@ -23,7 +24,7 @@ export const DocmapOnlineAccount = t.intersection([
   }),
   // t.type intersects t.partial to add optional fields
   t.partial({
-    service: t.string,
+    service: UrlFromString,
   }),
 ])
 
@@ -35,11 +36,10 @@ export const DocmapPublisher = t.intersection([
     // fields used by eLife
     id: t.string,
 
-    // TODO: add url typing?
-    logo: t.string,
+    logo: UrlFromString,
     name: t.string,
-    homepage: t.string,
-    url: t.string,
+    homepage: UrlFromString,
+    url: UrlFromString,
     account: DocmapOnlineAccount,
   }),
 ])
@@ -53,8 +53,8 @@ export const DocmapManifestation = t.intersection([
   }),
   t.partial({
     id: t.string,
-    service: t.string,
-    url: t.string,
+    service: UrlFromString,
+    url: UrlFromString,
   }),
 ])
 

--- a/packages/ts-sdk/src/util.ts
+++ b/packages/ts-sdk/src/util.ts
@@ -1,0 +1,29 @@
+import * as t from 'io-ts'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { chain } from 'fp-ts/lib/Either'
+
+/** URL from String parser
+ *
+ * based on example there:
+ *   https://github.com/gcanti/io-ts-types/blob/master/src/BooleanFromString.ts
+ */
+
+export type UrlFromStringC = t.Type<URL, string, unknown>
+
+export const UrlFromString: UrlFromStringC = new t.Type<URL, string, unknown>(
+  'UrlFromString',
+  (u): u is URL => u instanceof URL,
+  (u, c) =>
+    pipe(
+      t.string.validate(u, c),
+      chain((s) => {
+        try {
+          const url = new URL(s)
+          return t.success(url)
+        } catch (e) {
+          return t.failure(u, c)
+        }
+      }),
+    ),
+  String,
+)


### PR DESCRIPTION
Now, when we parse Docmapsy objects they will fail to validate if the date and url fields are malformed; they will additionally have the JS `Date` and `URL` objects to utilize conveniently.