### PR TITLE
[ts-sdk] Add date from unknown utility type

### DIFF
--- a/packages/ts-sdk/src/test/util.test.ts
+++ b/packages/ts-sdk/src/test/util.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { UrlFromString } from '../util'
+import { DateFromUnknown, UrlFromString } from '../util'
 import { isRight, Either } from 'fp-ts/lib/Either'
 
 function rightAnd<T>(e: Either<unknown, T>, validation: (res: T) => void) {
@@ -41,11 +41,51 @@ test('UrlFromString success cases', (t) => {
 
 test('UrlFromString failure cases', (t) => {
   const url1 = UrlFromString.decode('NOT_A_URL')
-  t.false(isRight(UrlFromString.decode(url1)))
+  t.false(isRight(url1))
 
   const url2 = UrlFromString.decode(409)
-  t.false(isRight(UrlFromString.decode(url2)))
+  t.false(isRight(url2))
 
   const url3 = UrlFromString.decode({})
-  t.false(isRight(UrlFromString.decode(url3)))
+  t.false(isRight(url3))
+})
+
+test('DateFromUnknown success cases', (t) => {
+  const d1 = DateFromUnknown.decode(new Date(0))
+  t.true(
+    rightAnd(d1, (d) => {
+      t.is(d.valueOf(), 0)
+      t.is(d.getUTCFullYear(), 1970)
+      t.is(DateFromUnknown.encode(d), '1970-01-01T00:00:00.000Z')
+    }),
+  )
+
+  const d2 = DateFromUnknown.decode(0)
+  t.true(
+    rightAnd(d2, (d) => {
+      t.is(d.valueOf(), 0)
+      t.is(d.getUTCFullYear(), 1970)
+      t.is(DateFromUnknown.encode(d), '1970-01-01T00:00:00.000Z')
+    }),
+  )
+
+  const d4 = DateFromUnknown.decode("1970-01-01T00:00:00.000Z")
+  t.true(
+    rightAnd(d4, (d) => {
+      t.is(d.valueOf(), 0)
+      t.is(d.getUTCFullYear(), 1970)
+      t.is(DateFromUnknown.encode(d), '1970-01-01T00:00:00.000Z')
+    }),
+  )
+})
+
+test('DateFromUnknown failure cases', (t) => {
+  const d1 = DateFromUnknown.decode('NOT_A_DATE')
+  t.false(isRight(d1))
+
+  const d2 = DateFromUnknown.decode(undefined)
+  t.false(isRight(d2))
+
+  const d4 = DateFromUnknown.decode({some: 'thing'})
+  t.false(isRight(d4))
 })

--- a/packages/ts-sdk/src/test/util.test.ts
+++ b/packages/ts-sdk/src/test/util.test.ts
@@ -69,7 +69,7 @@ test('DateFromUnknown success cases', (t) => {
     }),
   )
 
-  const d4 = DateFromUnknown.decode("1970-01-01T00:00:00.000Z")
+  const d4 = DateFromUnknown.decode('1970-01-01T00:00:00.000Z')
   t.true(
     rightAnd(d4, (d) => {
       t.is(d.valueOf(), 0)
@@ -86,6 +86,6 @@ test('DateFromUnknown failure cases', (t) => {
   const d2 = DateFromUnknown.decode(undefined)
   t.false(isRight(d2))
 
-  const d4 = DateFromUnknown.decode({some: 'thing'})
+  const d4 = DateFromUnknown.decode({ some: 'thing' })
   t.false(isRight(d4))
 })

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts'
-import { UrlFromString,DateFromUnknown } from './util'
+import { UrlFromString, DateFromUnknown } from './util'
 
 function arrayOrOneOf(literalStrings: string[]) {
   const [one, two, ...r] = literalStrings

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -1,6 +1,5 @@
 import * as t from 'io-ts'
-import { DateFromISOString } from 'io-ts-types'
-import { UrlFromString } from './util'
+import { UrlFromString,DateFromUnknown } from './util'
 
 function arrayOrOneOf(literalStrings: string[]) {
   const [one, two, ...r] = literalStrings
@@ -87,7 +86,7 @@ export const DocmapThing = t.intersection([
   t.partial({
     // TODO use DateFromString for better parsing:
     //    https://github.com/gcanti/io-ts/blob/dedb64e05328417ecd3d87e00008d9e72130374a/index.md#custom-types
-    published: DateFromISOString,
+    published: DateFromUnknown,
     id: t.string,
     doi: t.string,
     type: t.union([t.array(t.string), t.string]), // TODO this Type can be more specific ('web-page', 'preprint', etc)
@@ -137,12 +136,12 @@ export const Docmap = t.intersection([
     ]),
     publisher: DocmapPublisher,
     // TODO: required contents of these date strings,
-    created: DateFromISOString,
+    created: DateFromUnknown,
   }),
   t.partial({
     steps: t.record(t.string, DocmapStep),
     'first-step': t.string,
-    updated: DateFromISOString,
+    updated: DateFromUnknown,
   }),
 ])
 

--- a/packages/ts-sdk/src/util.ts
+++ b/packages/ts-sdk/src/util.ts
@@ -41,12 +41,12 @@ export const DateFromUnknown: DateFromUnknownC = new t.Type<Date, string, unknow
   (input: unknown): input is Date => input instanceof Date,
   (input, context) => {
     if (typeof input === 'string' || typeof input === 'number' || input instanceof Date) {
-      const date = new Date(input);
+      const date = new Date(input)
       if (!isNaN(date.getTime())) {
-        return t.success(date);
+        return t.success(date)
       }
     }
-    return t.failure(input, context, 'Invalid date-like input');
+    return t.failure(input, context, 'Invalid date-like input')
   },
   (date: Date) => date.toISOString(),
-);
+)

--- a/packages/ts-sdk/src/util.ts
+++ b/packages/ts-sdk/src/util.ts
@@ -27,3 +27,26 @@ export const UrlFromString: UrlFromStringC = new t.Type<URL, string, unknown>(
     ),
   String,
 )
+
+/** Date from Anything
+ *
+ * based on example there:
+ *   https://github.com/gcanti/io-ts/blob/master/index.md#custom-types
+ */
+
+export type DateFromUnknownC = t.Type<Date, string, unknown>
+
+export const DateFromUnknown: DateFromUnknownC = new t.Type<Date, string, unknown>(
+  'DateFromUnknown',
+  (input: unknown): input is Date => input instanceof Date,
+  (input, context) => {
+    if (typeof input === 'string' || typeof input === 'number' || input instanceof Date) {
+      const date = new Date(input);
+      if (!isNaN(date.getTime())) {
+        return t.success(date);
+      }
+    }
+    return t.failure(input, context, 'Invalid date-like input');
+  },
+  (date: Date) => date.toISOString(),
+);


### PR DESCRIPTION
## Description

Various types rely on encoded Dates, however when they are encoded as DateFromISOString they will fail when decoding a structured object with a Date field or a timestamp number. This encoding allows either option as well as string.

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [-] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

We may find that we wish to disallow use of a timestamp in these cases, however since these encoders always encode to string, i am not worried about it just yet.