### PR TITLE
sdk: allow unused vars with underscore prefix

### DIFF
--- a/packages/ts-sdk/.eslintrc.cjs
+++ b/packages/ts-sdk/.eslintrc.cjs
@@ -10,6 +10,13 @@ module.exports = {
   root: true,
   ignorePatterns: ['dist/'],
   rules: {
-    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
   },
 }


### PR DESCRIPTION
## Description

Minor change to allow introduction of unused vars with underscore prefix names.

### Related Issues

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [-] I have added or updated tests to cover any new functionality or bug fixes.
- [-] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information
