### PR TITLE
add typing for assertions

### DIFF
--- a/packages/ts-sdk/src/test/__fixtures__/from_root_examples.ts
+++ b/packages/ts-sdk/src/test/__fixtures__/from_root_examples.ts
@@ -43,6 +43,7 @@ const el_dm_publisher = el_dm.flatMap((dm) => dm['publisher'] || [])
 const el_dm_acc = el_dm_publisher.flatMap((p) => p['account'] || [])
 const el_dm_step: any[] = el_dm.flatMap((dm) => Object.values(dm['steps']) || [])
 const el_dm_action = el_dm_step.flatMap((s) => s['actions'] || [])
+const el_dm_assertion = el_dm_step.flatMap((s) => s['assertions'] || [])
 const el_dm_thing = el_dm_action.flatMap((a) => a['outputs'] || [])
 const el_dm_mani = el_dm_thing.flatMap((t) => t['content'] || [])
 const el_dm_role = el_dm_action.flatMap((a) => a['participants'] || [])
@@ -55,6 +56,7 @@ export const PartialExamples = {
     DocmapOnlineAccount: el_dm_acc,
     DocmapStep: el_dm_step,
     DocmapAction: el_dm_action,
+    DocmapAssertion: el_dm_assertion,
     DocmapThing: el_dm_thing,
     DocmapActor: el_dm_actor,
     DocmapRoleInTime: el_dm_role,

--- a/packages/ts-sdk/src/test/types.test.ts
+++ b/packages/ts-sdk/src/test/types.test.ts
@@ -65,6 +65,13 @@ test('Codec parsing DocmapAction', (t) => {
   isRightArray(t, v, 9)
 })
 
+test('Codec parsing DocmapAssertion', (t) => {
+  const v = ex.elife.DocmapAssertion.flatMap((x) => {
+    return dm.DocmapAssertion.decode(x)
+  })
+  isRightArray(t, v, 6)
+})
+
 test('Codec parsing DocmapStep', (t) => {
   const v = ex.elife.DocmapStep.flatMap((x) => {
     return dm.DocmapStep.decode(x)

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -105,13 +105,25 @@ export const DocmapAction = t.intersection([
   }),
 ])
 
+const DocmapStatus = t.string
+
+export const DocmapAssertion = t.intersection([
+  t.type({
+    item: t.unknown,
+    status: DocmapStatus,
+  }),
+  t.partial({
+    happened: DateFromUnknown,
+  }),
+])
+
 export const DocmapStep = t.intersection([
   t.type({
     actions: t.array(DocmapAction),
     inputs: t.array(DocmapThing),
 
     // TODO: make this smarter
-    assertions: t.array(t.unknown),
+    assertions: t.array(DocmapAssertion),
   }),
   t.partial({
     id: t.string,
@@ -155,6 +167,7 @@ export type DocmapActionT = t.TypeOf<typeof DocmapAction>
 export type DocmapThingT = t.TypeOf<typeof DocmapThing>
 export type DocmapRoleInTimeT = t.TypeOf<typeof DocmapRoleInTime>
 export type DocmapActorT = t.TypeOf<typeof DocmapActor>
+export type DocmapAssertionT = t.TypeOf<typeof DocmapAssertion>
 
 /**  DocmapsFactory
  *


### PR DESCRIPTION
## Description

Replaces `t.unknown` with a slightly more structured type for the Assertions. It is consistent with the jsonld specification - that the objects use `item` and `status`.

### Related Issues

https://github.com/Docmaps-Project/docmaps/issues/23 (indirectly)

### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [ ] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information
