### PR TITLE
add @context when missing

### DIFF
--- a/packages/ts-sdk/src/test/types.test.ts
+++ b/packages/ts-sdk/src/test/types.test.ts
@@ -9,14 +9,16 @@ function isRightArray<T>(
   t: ExecutionContext,
   arr: E.Either<unknown, T>[],
   len: number,
-  proc?: (_a: readonly T[]) => void) {
+  proc?: (_a: readonly T[]) => void,
+) {
   t.is(arr.length, len)
 
   pipe(
     arr,
     E.sequenceArray,
     E.mapLeft((e) => t.fail(`Error parsing: ${util.inspect(e, { depth: 18 })}`)),
-    E.map(proc || (() => {}))
+    //eslint-disable-next-line
+    E.map(proc || (() => {})),
   )
 }
 
@@ -87,20 +89,17 @@ test('Codec parsing Docmap', (t) => {
   const v = ex.elife.Docmap.flatMap((x) => {
     return dm.Docmap.decode(x)
   })
-  isRightArray(t, v, 2, (arr => {
+  isRightArray(t, v, 2, (arr) => {
     t.deepEqual(arr[0]?.['@context'], 'https://w3id.org/docmaps/context.jsonld')
-  }))
+  })
 })
 
 test('Codec inserts missing @context key for Docmap', (t) => {
   const v = ex.elife.Docmap.flatMap((x) => {
-    const {
-      ['@context']: _,
-      ...stripped
-    } = x
+    const { ['@context']: _, ...stripped } = x
     return dm.Docmap.decode(stripped)
   })
-  isRightArray(t, v, 2, (arr => {
+  isRightArray(t, v, 2, (arr) => {
     t.deepEqual(arr[0]?.['@context'], 'https://w3id.org/docmaps/context.jsonld')
-  }))
+  })
 })

--- a/packages/ts-sdk/src/test/types.test.ts
+++ b/packages/ts-sdk/src/test/types.test.ts
@@ -2,7 +2,7 @@ import test, { ExecutionContext } from 'ava'
 import { PartialExamples as ex } from './__fixtures__'
 import * as dm from '../types'
 import * as E from 'fp-ts/lib/Either'
-import util from 'util'
+import * as util from 'util'
 import { pipe } from 'fp-ts/lib/pipeable'
 
 function isRightArray<T>(

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts'
+import { fromNullable } from 'io-ts-types/lib/fromNullable'
 import { UrlFromString, DateFromUnknown } from './util'
 
 function arrayOrOneOf(literalStrings: string[]) {
@@ -137,6 +138,11 @@ export const DocmapStep = t.intersection([
 export const Docmap = t.intersection([
   t.type({
     id: t.string,
+    // only one legal value, and fill it if absent
+    '@context': fromNullable(
+      t.literal('https://w3id.org/docmaps/context.jsonld'),
+      'https://w3id.org/docmaps/context.jsonld'
+    ),
     type: arrayOrOneOf([
       // TODO support something where docmaps: is prefixed
       // t.literal('docmaps:docmap'),

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -141,7 +141,7 @@ export const Docmap = t.intersection([
     // only one legal value, and fill it if absent
     '@context': fromNullable(
       t.literal('https://w3id.org/docmaps/context.jsonld'),
-      'https://w3id.org/docmaps/context.jsonld'
+      'https://w3id.org/docmaps/context.jsonld',
     ),
     type: arrayOrOneOf([
       // TODO support something where docmaps: is prefixed


### PR DESCRIPTION
## Description

The Docmap codec will now always return a value with @context key set. If the @context key is set to something other than the correct context, it will fail to decode (do we want this behavior?) If it is empty or null, it will be set to the correct key.

### Related Issues

This should improve interoperability with JSON-LD.

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [x] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Provide any additional information that might be helpful in understanding this pull request, such as screenshots, links to relevant research, or other context.
