### PR TITLE
remove prefix strings from type names

### DIFF
--- a/packages/ts-etl/src/command.ts
+++ b/packages/ts-etl/src/command.ts
@@ -1,6 +1,6 @@
 import type { CrossrefClient } from 'crossref-openapi-client-ts'
 import { Command, Option } from '@commander-js/extra-typings'
-import { DocmapPublisher, DocmapPublisherT } from 'docmaps-sdk'
+import { Publisher, PublisherT } from 'docmaps-sdk'
 import { isLeft, right } from 'fp-ts/lib/Either'
 
 import * as crossref from './plugins/crossref'
@@ -52,7 +52,7 @@ export function MakeCli() {
     .option('--publisher.homepage <homepage>', 'homepage of publisher of docmaps to generate (you)')
     .option('--publisher.logo <logo>', 'logo of publisher of docmaps to generate (you)')
     .action(async (doi, options) => {
-      const pub = DocmapPublisher.decode({
+      const pub = Publisher.decode({
         id: options['publisher.id'],
         name: options['publisher.name'],
         homepage: options['publisher.homepage'],
@@ -124,7 +124,7 @@ export interface CrossrefConfiguration {
  */
 export interface ItemOpts {
   source: CrossrefConfiguration
-  publisher: DocmapPublisherT
+  publisher: PublisherT
 }
 
 /**

--- a/packages/ts-etl/src/plugins/crossref/api.ts
+++ b/packages/ts-etl/src/plugins/crossref/api.ts
@@ -22,8 +22,8 @@ export const Client = CreateCrossrefClient({})
 // for now without going all the way to a graphy representation
 // in this procedure.
 type RecursiveStepDataChain = {
-  head: D.DocmapStepT
-  all: D.DocmapStepT[]
+  head: D.StepT
+  all: D.StepT[]
 }
 
 function stepsForDoiRecursive(
@@ -56,7 +56,7 @@ function stepsForDoiRecursive(
             },
           ],
         })),
-        E.chain((action) => pipe(D.DocmapStep.decode(action), mapLeftToUnknownError)),
+        E.chain((action) => pipe(D.Step.decode(action), mapLeftToUnknownError)),
         E.map((s) => ({
           all: [s],
           head: s,
@@ -89,10 +89,10 @@ function stepsForDoiRecursive(
 
           const newStep = {
             ...initialChain.head,
-            inputs: meta.reduce<D.DocmapThingT[]>(
+            inputs: meta.reduce<D.ThingT[]>(
               (memo, c) =>
                 memo.concat(
-                  c.head.actions.reduce<D.DocmapThingT[]>((m, a) => m.concat(a.outputs), []),
+                  c.head.actions.reduce<D.ThingT[]>((m, a) => m.concat(a.outputs), []),
                 ),
               [],
             ),
@@ -100,7 +100,7 @@ function stepsForDoiRecursive(
 
           return {
             head: newStep,
-            all: meta.reduce<D.DocmapStepT[]>((m, c) => m.concat(c.all), []).concat([newStep]),
+            all: meta.reduce<D.StepT[]>((m, c) => m.concat(c.all), []).concat([newStep]),
           }
         }),
       )
@@ -133,7 +133,7 @@ function stepsForDoiRecursive(
             },
           ],
         })),
-        TE.chainEitherK((rs) => mapLeftToUnknownError(D.DocmapStep.decode(rs))),
+        TE.chainEitherK((rs) => mapLeftToUnknownError(D.Step.decode(rs))),
         TE.map((reviewStep) => ({
           head: prefixChain.head,
           all: prefixChain.all.concat([reviewStep]),
@@ -148,7 +148,7 @@ function stepsForDoiRecursive(
 
 export async function fetchPublicationByDoi(
   client: CrossrefClient,
-  publisher: D.DocmapPublisherT,
+  publisher: D.PublisherT,
   inputDoi: string,
 ): Promise<ErrorOrDocmap> {
   const resultTask = pipe(
@@ -172,7 +172,7 @@ export async function fetchPublicationByDoi(
 export function actionForReviewDOI(
   client: CrossrefClient,
   doi: string,
-): TE.TaskEither<Error, D.DocmapActionT> {
+): TE.TaskEither<Error, D.ActionT> {
   const service = client.works
   return pipe(
     TE.tryCatch(

--- a/packages/ts-etl/src/plugins/crossref/api.ts
+++ b/packages/ts-etl/src/plugins/crossref/api.ts
@@ -91,9 +91,7 @@ function stepsForDoiRecursive(
             ...initialChain.head,
             inputs: meta.reduce<D.ThingT[]>(
               (memo, c) =>
-                memo.concat(
-                  c.head.actions.reduce<D.ThingT[]>((m, a) => m.concat(a.outputs), []),
-                ),
+                memo.concat(c.head.actions.reduce<D.ThingT[]>((m, a) => m.concat(a.outputs), [])),
               [],
             ),
           }

--- a/packages/ts-etl/src/plugins/crossref/functions.ts
+++ b/packages/ts-etl/src/plugins/crossref/functions.ts
@@ -22,7 +22,7 @@ function nameForAuthor(a: { family: string; name?: string; given?: string }): st
   return a.name || (a.given ? `${a.family}, ${a.given}` : a.family)
 }
 
-export function decodeActionForWork(work: Work): E.Either<Error, D.DocmapActionT> {
+export function decodeActionForWork(work: Work): E.Either<Error, D.ActionT> {
   return pipe(
     E.Do,
     // prepare the Thing which will be output
@@ -35,7 +35,7 @@ export function decodeActionForWork(work: Work): E.Either<Error, D.DocmapActionT
           type: 'person',
           name: nameForAuthor(a),
         })),
-        E.traverseArray((a) => mapLeftToUnknownError(D.DocmapActor.decode(a))),
+        E.traverseArray((a) => mapLeftToUnknownError(D.Actor.decode(a))),
         E.map((auths) =>
           auths.map((a) => ({
             actor: a,
@@ -51,7 +51,7 @@ export function decodeActionForWork(work: Work): E.Either<Error, D.DocmapActionT
           participants: wa,
           outputs: [wo],
         },
-        D.DocmapAction.decode,
+        D.Action.decode,
         mapLeftToUnknownError,
       ),
     ),
@@ -71,9 +71,9 @@ export function decodeActionForWork(work: Work): E.Either<Error, D.DocmapActionT
  * This is an awkward moment that breaks some of the functional abstraction (see comments).
  */
 export function stepArrayToDocmap(
-  publisher: D.DocmapPublisherT,
+  publisher: D.PublisherT,
   inputDoi: string,
-  [firstStep, ...steps]: D.DocmapStepT[],
+  [firstStep, ...steps]: D.StepT[],
 ): ErrorOrDocmap {
   // TODO: extract this logic
   const dm_id = `https://docmaps-project.github.io/ex/docmap_for/${inputDoi}`
@@ -103,7 +103,7 @@ export function stepArrayToDocmap(
   // this reduction takes advantage of the fact that we have separated the firstStep
   // from the ...steps argument, because the first & last step is only singly linked
   //   (see the last argument to #reduce).
-  const reduction = steps.reduce<E.Either<Error, Record<string, D.DocmapStepT>>>(
+  const reduction = steps.reduce<E.Either<Error, Record<string, D.StepT>>>(
     (memo, next) => {
       if (E.isLeft(memo)) {
         return memo //cascade all errors

--- a/packages/ts-etl/test/unit/crossref/functions.test.ts
+++ b/packages/ts-etl/test/unit/crossref/functions.test.ts
@@ -3,7 +3,7 @@ import * as cm from '../__fixtures__/crossref'
 import * as E from 'fp-ts/lib/Either'
 import { inspect } from 'util'
 import * as F from '../../../src/plugins/crossref/functions'
-import type { DocmapActionT } from 'docmaps-sdk'
+import type { ActionT } from 'docmaps-sdk'
 
 function rightOrInspectError<T>(
   t: ExecutionContext,
@@ -31,7 +31,7 @@ test('decodeActionForWork: no authors', async (t) => {
   t.true(
     rightOrInspectError(
       t,
-      (action: DocmapActionT) => {
+      (action: ActionT) => {
         t.is(action.outputs[0]?.doi, 'mock.decodeAction')
         t.deepEqual(action.participants, [])
       },
@@ -55,7 +55,7 @@ test('decodeActionForWork: with authors', async (t) => {
   t.true(
     rightOrInspectError(
       t,
-      (action: DocmapActionT) => {
+      (action: ActionT) => {
         t.is(action.outputs[0]?.doi, 'mock.decodeAction')
         t.is(action.participants[0]?.role, 'author')
         t.is(action.participants[1]?.role, 'author')

--- a/packages/ts-sdk/src/test/__fixtures__/from_root_examples.ts
+++ b/packages/ts-sdk/src/test/__fixtures__/from_root_examples.ts
@@ -52,14 +52,14 @@ const el_dm_actor = el_dm_role.map((r) => r['actor'] || [])
 export const PartialExamples = {
   elife: {
     Docmap: el_dm,
-    DocmapPublisher: el_dm_publisher,
-    DocmapOnlineAccount: el_dm_acc,
-    DocmapStep: el_dm_step,
-    DocmapAction: el_dm_action,
-    DocmapAssertion: el_dm_assertion,
-    DocmapThing: el_dm_thing,
-    DocmapActor: el_dm_actor,
-    DocmapRoleInTime: el_dm_role,
-    DocmapManifestation: el_dm_mani,
+    Publisher: el_dm_publisher,
+    OnlineAccount: el_dm_acc,
+    Step: el_dm_step,
+    Action: el_dm_action,
+    Assertion: el_dm_assertion,
+    Thing: el_dm_thing,
+    Actor: el_dm_actor,
+    RoleInTime: el_dm_role,
+    Manifestation: el_dm_mani,
   },
 }

--- a/packages/ts-sdk/src/test/typed_graph.test.ts
+++ b/packages/ts-sdk/src/test/typed_graph.test.ts
@@ -9,7 +9,7 @@ const g = new TypedGraph(factory)
 test('Graph Extraction of a Manifestation', async (t) => {
   const mf = (await g.pickStream(OneManifestationQuadstore(), {
     type: 'web-page', // selects the Publisher
-  })) as DocmapsTypes.DocmapManifestationT
+  })) as DocmapsTypes.ManifestationT
 
   t.is(mf.id, 'https://w3id.org/docmaps/examples/manifestation')
   t.is(mf.service?.hostname, 'w3id.org')
@@ -63,7 +63,7 @@ test('Parsing JSONLD from concrete embo examples', async (t) => {
 // test('Graph Extraction of a publisher', async (t) => {
 //   const pub = await g.pickStream(OnePublisherQuadstore(), {
 //     'type': "foaf:organization", // selects the Publisher
-//   }) as DocmapsTypes.DocmapPublisherT;
+//   }) as DocmapsTypes.PublisherT;
 //
 //   t.is(pub.id, 'https://w3id.org/docmaps/examples/publisher');
 //   t.is(pub.name, 'Example Publisher');

--- a/packages/ts-sdk/src/test/types.test.ts
+++ b/packages/ts-sdk/src/test/types.test.ts
@@ -22,65 +22,65 @@ function isRightArray<T>(
   )
 }
 
-test('Codec parsing DocmapOnlineAccount', (t) => {
-  const v = ex.elife.DocmapOnlineAccount.flatMap((x) => {
-    return dm.DocmapOnlineAccount.decode(x)
+test('Codec parsing OnlineAccount', (t) => {
+  const v = ex.elife.OnlineAccount.flatMap((x) => {
+    return dm.OnlineAccount.decode(x)
   })
   isRightArray(t, v, 1)
 })
 
-test('Codec parsing DocmapPublisher', (t) => {
-  const v = ex.elife.DocmapPublisher.flatMap((x) => {
-    return dm.DocmapPublisher.decode(x)
+test('Codec parsing Publisher', (t) => {
+  const v = ex.elife.Publisher.flatMap((x) => {
+    return dm.Publisher.decode(x)
   })
   isRightArray(t, v, 2)
 })
 
-test('Codec parsing DocmapManifestation', (t) => {
-  const v = ex.elife.DocmapManifestation.flatMap((x) => {
-    return dm.DocmapManifestation.decode(x)
+test('Codec parsing Manifestation', (t) => {
+  const v = ex.elife.Manifestation.flatMap((x) => {
+    return dm.Manifestation.decode(x)
   })
   isRightArray(t, v, 21)
 })
 
-test('Codec parsing DocmapThing', (t) => {
-  const v = ex.elife.DocmapThing.flatMap((x) => {
-    return dm.DocmapThing.decode(x)
+test('Codec parsing Thing', (t) => {
+  const v = ex.elife.Thing.flatMap((x) => {
+    return dm.Thing.decode(x)
   })
   isRightArray(t, v, 9)
 })
 
-test('Codec parsing DocmapRoleInTime', (t) => {
-  const v = ex.elife.DocmapRoleInTime.flatMap((x) => {
-    return dm.DocmapRoleInTime.decode(x)
+test('Codec parsing RoleInTime', (t) => {
+  const v = ex.elife.RoleInTime.flatMap((x) => {
+    return dm.RoleInTime.decode(x)
   })
   isRightArray(t, v, 9)
 })
 
-test('Codec parsing DocmapActor', (t) => {
-  const v = ex.elife.DocmapActor.flatMap((x) => {
-    return dm.DocmapActor.decode(x)
+test('Codec parsing Actor', (t) => {
+  const v = ex.elife.Actor.flatMap((x) => {
+    return dm.Actor.decode(x)
   })
   isRightArray(t, v, 9)
 })
 
-test('Codec parsing DocmapAction', (t) => {
-  const v = ex.elife.DocmapAction.flatMap((x) => {
-    return dm.DocmapAction.decode(x)
+test('Codec parsing Action', (t) => {
+  const v = ex.elife.Action.flatMap((x) => {
+    return dm.Action.decode(x)
   })
   isRightArray(t, v, 9)
 })
 
-test('Codec parsing DocmapAssertion', (t) => {
-  const v = ex.elife.DocmapAssertion.flatMap((x) => {
-    return dm.DocmapAssertion.decode(x)
+test('Codec parsing Assertion', (t) => {
+  const v = ex.elife.Assertion.flatMap((x) => {
+    return dm.Assertion.decode(x)
   })
   isRightArray(t, v, 6)
 })
 
-test('Codec parsing DocmapStep', (t) => {
-  const v = ex.elife.DocmapStep.flatMap((x) => {
-    return dm.DocmapStep.decode(x)
+test('Codec parsing Step', (t) => {
+  const v = ex.elife.Step.flatMap((x) => {
+    return dm.Step.decode(x)
   })
   isRightArray(t, v, 5)
 })

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -18,7 +18,7 @@ function arrayOrOneOf(literalStrings: string[]) {
   return t.union([t.array(literals), literals])
 }
 
-export const DocmapOnlineAccount = t.intersection([
+export const OnlineAccount = t.intersection([
   t.type({
     id: t.string,
     // TODO: is actually a `foaf:onlineaccount`, but that is not specified in the JSON_LD. TBD whetehr that would be enough of a constraint.
@@ -29,7 +29,7 @@ export const DocmapOnlineAccount = t.intersection([
   }),
 ])
 
-export const DocmapPublisher = t.intersection([
+export const Publisher = t.intersection([
   t.type({
     // TODO this is not so useful as partial-only
   }),
@@ -41,11 +41,11 @@ export const DocmapPublisher = t.intersection([
     name: t.string,
     homepage: UrlFromString,
     url: UrlFromString,
-    account: DocmapOnlineAccount,
+    account: OnlineAccount,
   }),
 ])
 
-export const DocmapManifestation = t.intersection([
+export const Manifestation = t.intersection([
   t.type({
     // TODO: this looks like it might need to be an AnyType or something. Manifestations are extensive.
     type: arrayOrOneOf([
@@ -59,7 +59,7 @@ export const DocmapManifestation = t.intersection([
   }),
 ])
 
-export const DocmapActor = t.union([
+export const Actor = t.union([
   t.type({
     type: arrayOrOneOf(['person']),
     name: t.string,
@@ -68,9 +68,9 @@ export const DocmapActor = t.union([
   t.unknown,
 ])
 
-export const DocmapRoleInTime = t.intersection([
+export const RoleInTime = t.intersection([
   t.type({
-    actor: DocmapActor,
+    actor: Actor,
     // TODO: this may need to be more specific to the RoleInTimes.
     role: t.string,
   }),
@@ -80,7 +80,7 @@ export const DocmapRoleInTime = t.intersection([
   }),
 ])
 
-export const DocmapThing = t.intersection([
+export const Thing = t.intersection([
   t.type({
     // TODO this is not so useful as partial-only
   }),
@@ -91,14 +91,14 @@ export const DocmapThing = t.intersection([
     id: t.string,
     doi: t.string,
     type: t.union([t.array(t.string), t.string]), // TODO this Type can be more specific ('web-page', 'preprint', etc)
-    content: t.array(DocmapManifestation),
+    content: t.array(Manifestation),
   }),
 ])
 
-export const DocmapAction = t.intersection([
+export const Action = t.intersection([
   t.type({
-    outputs: t.array(DocmapThing),
-    participants: t.array(DocmapRoleInTime),
+    outputs: t.array(Thing),
+    participants: t.array(RoleInTime),
   }),
   t.partial({
     // TODO - this will probably be an independently-publishable thing and id should not be optional.
@@ -106,25 +106,25 @@ export const DocmapAction = t.intersection([
   }),
 ])
 
-const DocmapStatus = t.string
+const Status = t.string
 
-export const DocmapAssertion = t.intersection([
+export const Assertion = t.intersection([
   t.type({
     item: t.unknown,
-    status: DocmapStatus,
+    status: Status,
   }),
   t.partial({
     happened: DateFromUnknown,
   }),
 ])
 
-export const DocmapStep = t.intersection([
+export const Step = t.intersection([
   t.type({
-    actions: t.array(DocmapAction),
-    inputs: t.array(DocmapThing),
+    actions: t.array(Action),
+    inputs: t.array(Thing),
 
     // TODO: make this smarter
-    assertions: t.array(DocmapAssertion),
+    assertions: t.array(Assertion),
   }),
   t.partial({
     id: t.string,
@@ -152,28 +152,28 @@ export const Docmap = t.intersection([
       'Docmap',
       'https://w3id.org/docmaps/v0/Docmap',
     ]),
-    publisher: DocmapPublisher,
+    publisher: Publisher,
     // TODO: required contents of these date strings,
     created: DateFromUnknown,
   }),
   t.partial({
-    steps: t.record(t.string, DocmapStep),
+    steps: t.record(t.string, Step),
     'first-step': t.string,
     updated: DateFromUnknown,
   }),
 ])
 
 export type IRI = string
-export type DocmapPublisherT = t.TypeOf<typeof DocmapPublisher>
-export type DocmapOnlineAccountT = t.TypeOf<typeof DocmapOnlineAccount>
-export type DocmapManifestationT = t.TypeOf<typeof DocmapManifestation>
-export type DocmapStepT = t.TypeOf<typeof DocmapStep>
+export type PublisherT = t.TypeOf<typeof Publisher>
+export type OnlineAccountT = t.TypeOf<typeof OnlineAccount>
+export type ManifestationT = t.TypeOf<typeof Manifestation>
+export type StepT = t.TypeOf<typeof Step>
 export type DocmapT = t.TypeOf<typeof Docmap>
-export type DocmapActionT = t.TypeOf<typeof DocmapAction>
-export type DocmapThingT = t.TypeOf<typeof DocmapThing>
-export type DocmapRoleInTimeT = t.TypeOf<typeof DocmapRoleInTime>
-export type DocmapActorT = t.TypeOf<typeof DocmapActor>
-export type DocmapAssertionT = t.TypeOf<typeof DocmapAssertion>
+export type ActionT = t.TypeOf<typeof Action>
+export type ThingT = t.TypeOf<typeof Thing>
+export type RoleInTimeT = t.TypeOf<typeof RoleInTime>
+export type ActorT = t.TypeOf<typeof Actor>
+export type AssertionT = t.TypeOf<typeof Assertion>
 
 /**  DocmapsFactory
  *
@@ -181,7 +181,7 @@ export type DocmapAssertionT = t.TypeOf<typeof DocmapAssertion>
  *  This is only used in the Typed Graph Extraction code.
  */
 export const DocmapsFactory = {
-  'web-page': DocmapManifestation,
+  'web-page': Manifestation,
   docmap: Docmap,
   'https://w3id.org/docmaps/v0/Docmap': Docmap,
   Docmap: Docmap,


### PR DESCRIPTION
## Description

Changes names like `DocmapAssertion` to `Assertion`, `DocmapAction` to `Action`, etc.

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [x] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

This fix should improve useability as you can always import * as if you need to differentiate. This will be annoying to deprecate later, so let's go before 1.0 is released.
