### PR TITLE
Allow polite mailto specification in ETL

### DIFF
--- a/packages/spa/src/utils.js
+++ b/packages/spa/src/utils.js
@@ -1,4 +1,4 @@
-import { ItemCmd, Client as CrossrefClient } from '@docmaps/etl'
+import { ItemCmd, CreateCrossrefClient } from '@docmaps/etl'
 import util from 'util'
 import {isLeft} from 'fp-ts/lib/Either'
 
@@ -8,7 +8,9 @@ export async function configureForDoiString(str, handleJson, handleError) {
     {
       source: {
 	preset: 'crossref-api',
-	client: CrossrefClient,
+	client: CreateCrossrefClient({
+	  politeMailto: "docmaps+spa@knowledgefutures.org"
+	}),
       },
       publisher: {
 	name: 'Inferred from Crossref',

--- a/packages/ts-etl/src/command.ts
+++ b/packages/ts-etl/src/command.ts
@@ -1,4 +1,4 @@
-import type { CrossrefClient } from 'crossref-openapi-client-ts'
+import { CrossrefClient, CreateCrossrefClient } from 'crossref-openapi-client-ts'
 import { Command, Option } from '@commander-js/extra-typings'
 import { Publisher, PublisherT } from 'docmaps-sdk'
 import { isLeft, right } from 'fp-ts/lib/Either'
@@ -46,6 +46,10 @@ export function MakeCli() {
         .choices(PLUGINOPTIONS)
         .makeOptionMandatory(),
     )
+    .option(
+      '--source.crossrefApi.politeMailto <email>',
+      'email for crossref api polite label (your email)',
+    )
     .option('--publisher.id <id>', 'id of publisher of docmaps to generate (you)')
     .option('--publisher.name <name>', 'name of publisher of docmaps to generate (you)')
     .option('--publisher.url <url>', 'url of publisher of docmaps to generate (you)')
@@ -65,10 +69,18 @@ export function MakeCli() {
         throw 'unreachable, if cli.error exits (?)'
       }
 
+      const politeMailto = options['source.crossrefApi.politeMailto']
+
+      const crossrefConfig = politeMailto
+        ? {
+            politeMailto,
+          }
+        : {}
+
       const o: ItemOpts = {
         source: {
           preset: options.source,
-          client: crossref.Client,
+          client: CreateCrossrefClient(crossrefConfig),
         },
         publisher: pub.right,
       }

--- a/packages/ts-etl/src/command.ts
+++ b/packages/ts-etl/src/command.ts
@@ -1,4 +1,4 @@
-import { CrossrefClient, CreateCrossrefClient } from 'crossref-openapi-client-ts'
+import type { CrossrefClient } from 'crossref-openapi-client-ts'
 import { Command, Option } from '@commander-js/extra-typings'
 import { Publisher, PublisherT } from 'docmaps-sdk'
 import { isLeft, right } from 'fp-ts/lib/Either'
@@ -80,7 +80,7 @@ export function MakeCli() {
       const o: ItemOpts = {
         source: {
           preset: options.source,
-          client: CreateCrossrefClient(crossrefConfig),
+          client: crossref.CreateCrossrefClient(crossrefConfig),
         },
         publisher: pub.right,
       }

--- a/packages/ts-etl/src/plugins/crossref/api.ts
+++ b/packages/ts-etl/src/plugins/crossref/api.ts
@@ -1,4 +1,4 @@
-import { CreateCrossrefClient, CrossrefClient } from 'crossref-openapi-client-ts'
+import type { CrossrefClient } from 'crossref-openapi-client-ts'
 import * as E from 'fp-ts/lib/Either'
 import * as A from 'fp-ts/lib/Array'
 import type { ErrorOrDocmap } from '../../types'
@@ -12,9 +12,6 @@ import {
   stepArrayToDocmap,
   thingForCrossrefWork,
 } from './functions'
-
-// TODO: force consumers of this library to supply a polite-mailto
-export const Client = CreateCrossrefClient({})
 
 // This type is needed because the recursion may produce steps in
 // order with review step last, but the preprint step must be

--- a/packages/ts-etl/src/plugins/crossref/api.ts
+++ b/packages/ts-etl/src/plugins/crossref/api.ts
@@ -13,6 +13,8 @@ import {
   thingForCrossrefWork,
 } from './functions'
 
+export { CreateCrossrefClient } from 'crossref-openapi-client-ts'
+
 // This type is needed because the recursion may produce steps in
 // order with review step last, but the preprint step must be
 // known to the recursing caller. This is awkward but workable

--- a/packages/ts-etl/test/integration/crossref.test.ts
+++ b/packages/ts-etl/test/integration/crossref.test.ts
@@ -37,7 +37,9 @@ async function cmdIoResults(args: string): Promise<cmdResult> {
 }
 
 test('single item from crossref with one preprint deduped', async (t) => {
-  const { stdout, error } = await cmdIoResults('item --source crossref-api 10.5194/acp-9-8413-2009')
+  const { stdout, error } = await cmdIoResults(
+    'item --source crossref-api 10.5194/acp-9-8413-2009 --source.crossrefApi.politeMailto docmaps+testsuite@knowledgefutures.org',
+  )
 
   t.falsy(error)
 
@@ -59,7 +61,7 @@ test('single item from crossref with one preprint deduped', async (t) => {
 
 test('single item from crossref with no relations', async (t) => {
   const { stdout, error } = await cmdIoResults(
-    'item --source crossref-api 10.1016/j.jaac.2016.07.660',
+    'item --source crossref-api 10.1016/j.jaac.2016.07.660 --source.crossrefApi.politeMailto docmaps+testsuite@knowledgefutures.org',
   )
 
   t.falsy(error)
@@ -82,7 +84,7 @@ test('single item from crossref with no relations', async (t) => {
 
 test('single item from crossref with both preprint and reviews', async (t) => {
   const { stdout, error } = await cmdIoResults(
-    'item --source crossref-api 10.5194/angeo-40-247-2022',
+    'item --source crossref-api 10.5194/angeo-40-247-2022 --source.crossrefApi.politeMailto docmaps+testsuite@knowledgefutures.org',
   )
 
   t.falsy(error)


### PR DESCRIPTION
## Description

Expose the configuration for the crossref client that the ETL uses to alert crossref API to who is using it. Allows access to better pools.

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [x] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

https://api.crossref.org/swagger-ui/index.html#Etiquette