### PR TITLE
fix case sensitivity bug

### DIFF
--- a/packages/ts-etl/src/plugins/crossref/api.ts
+++ b/packages/ts-etl/src/plugins/crossref/api.ts
@@ -86,7 +86,7 @@ function stepsForDoiRecursive(
         E.map((s) => ({
           head: s,
           all: [s],
-          visitedIds: visitedIds.add(inputDoi),
+          visitedIds: visitedIds.add(inputDoi.toLowerCase()),
         })),
         TE.fromEither,
       ),

--- a/packages/ts-etl/test/integration/crossref.test.ts
+++ b/packages/ts-etl/test/integration/crossref.test.ts
@@ -109,3 +109,31 @@ test('single item from crossref with both preprint and reviews', async (t) => {
 
   t.true(stdout.length < 4000) // depends on the actual example chosen. but this is to prevent regressions from explosions of added keys.
 })
+
+test('item from crossref with complex entanglement does not infinitely recurse', async (t) => {
+  const { stdout, error } = await cmdIoResults(
+    'item --source crossref-api 10.1130/G50960.1 --source.crossrefApi.politeMailto docmaps+testsuite-recursive@knowledgefutures.org',
+  )
+
+  t.falsy(error)
+
+  const dmArr = JSON.parse(stdout) as Array<DocmapT>
+
+  t.is(dmArr[0]?.['type'], 'docmap')
+  t.is(dmArr[0]?.['first-step'], '_:b0')
+  t.truthy(dmArr[0]?.['steps'])
+
+  const steps = dmArr[0]?.steps
+  if (!steps) {
+    t.fail('expected 4 steps')
+    return
+  }
+
+  t.is(Object.keys(steps).length, 4)
+  t.is(steps['_:b0']?.assertions[0]?.['status'], 'catalogued')
+  t.is(steps['_:b1']?.assertions[0]?.['status'], 'catalogued')
+  t.is(steps['_:b2']?.assertions[0]?.['status'], 'catalogued')
+  t.is(steps['_:b3']?.assertions[0]?.['status'], 'published')
+
+  t.true(stdout.length < 4000) // depends on the actual example chosen. but this is to prevent regressions from explosions of added keys.
+})


### PR DESCRIPTION
## Description

When the crossref ETL plugin is processing its visitedIDs, it previously lowercased all IDs when checking for presence because DOIs are case-insensitive. However they were noot lowercased when inserting to the set, meaning any DOI with a capital letter is never considered "visited". This no longer occurs.

### Related Issues

Case sensitivity is responsible for at least some of the error cases once believed attributable to #84 's use case.

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [x] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information
