### PR TITLE
script improvement: handle multiline jsonld[lines] files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "multi-semantic-release": "^3.0.2",
     "rdf-ext": "^2.2.0",
     "rdf-validate-shacl": "^0.4.5"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ importers:
       multi-semantic-release: ^3.0.2
       rdf-ext: ^2.2.0
       rdf-validate-shacl: ^0.4.5
+      typescript: ^4.9.5
     dependencies:
       '@manypkg/cli': 0.21.0
       '@rdfjs/formats-common': 3.1.0
@@ -23,6 +24,8 @@ importers:
       multi-semantic-release: 3.0.2
       rdf-ext: 2.2.0
       rdf-validate-shacl: 0.4.5
+    devDependencies:
+      typescript: 4.9.5
 
   packages/example:
     specifiers:

--- a/scripts/jsonld-to-rdf.js
+++ b/scripts/jsonld-to-rdf.js
@@ -1,41 +1,69 @@
-import ParserJsonld from '@rdfjs/parser-jsonld'
-import Serializer from '@rdfjs/serializer-turtle'
-import ParserN3 from '@rdfjs/parser-n3'
-import formats from '@rdfjs/formats-common'
-import SerializerNtriples from '@rdfjs/serializer-ntriples'
-import { Readable, Transform } from 'stream'
+import ParserJsonld from "@rdfjs/parser-jsonld";
+import Serializer from "@rdfjs/serializer-turtle";
+import ParserN3 from "@rdfjs/parser-n3";
+import formats from "@rdfjs/formats-common";
+import SerializerNtriples from "@rdfjs/serializer-ntriples";
+import { Readable, Transform } from "stream";
 import fs from "fs";
+import readline from "readline";
 
-const BASE_IRI='https://w3id.org/docmaps/examples/'
+const BASE_IRI = "https://w3id.org/docmaps/examples/";
 
-async function loadFile(fileName) {
+async function processFile(fileName, callback) {
   try {
-    const data = await fs.promises.readFile(fileName, "utf-8");
-    return data;
+    const readStream = readline.createInterface({
+      input: fs.createReadStream(fileName, "utf-8"),
+    });
+
+    let i = 0;
+
+    for await (const line of readStream) {
+      console.error(
+        `${i} ... Processing graph: ${line.substring(0, 120)} with length ${line.length
+        }`,
+      );
+      await callback(line);
+      i++;
+    }
   } catch (err) {
     console.error(err);
   }
 }
 
+async function processGraphString(g) {
+  const input = new Readable({
+    read: () => {
+      input.push(g);
+      input.push(null);
+    },
+  });
+
+  return new Promise((res, rej) => {
+    const parserJsonld = new ParserJsonld({
+      baseIRI: BASE_IRI,
+      steamingProfile: false,
+    });
+    const serializerNtriples = new SerializerNtriples();
+
+    // TODO: include declaration that a docmap is a :Docmap
+    const quads = parserJsonld.import(input);
+
+    const nt = serializerNtriples.import(quads);
+    nt.on("data", (d) => {
+      process.stdout.write(d);
+    })
+      .on("end", () => {
+        res();
+      })
+      .on("close", (err) => {
+        if (err) {
+          rej(err);
+        } else {
+          res();
+        }
+      });
+  });
+}
+
 const fileName = process.argv[2];
-const  data = await loadFile(fileName);
-
-const parserJsonld = new ParserJsonld({baseIRI: BASE_IRI})
-const serializerNtriples = new SerializerNtriples()
-const serializer = new Serializer()
-
-const input = new Readable({
-  read: () => {
-    input.push(data)
-    input.push(null)
-  }
-})
-
-// TODO: include declaration that a docmap is a :Docmap
-const quads = parserJsonld.import(input)
-
-const nt = serializerNtriples.import(quads)
-
-// TODO: add conversion to turtle as well.
-nt.pipe(process.stdout)
-
+const _ = await processFile(fileName, processGraphString);


### PR DESCRIPTION
## Description

The jsonld-to-rdf script previously was unable to handle jsonld files with multiple top-level objects, like a jsonlines file. This change now supports that format of file.

### Related Issues

No issues mention this specifically but it was made to support dataset generation while exploring for #93 

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [x] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Provide any additional information that might be helpful in understanding this pull request, such as screenshots, links to relevant research, or other context.
