### PR TITLE
http-client: move over http-client package

### DIFF
--- a/packages/http-client/.eslintrc.cjs
+++ b/packages/http-client/.eslintrc.cjs
@@ -1,0 +1,23 @@
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:prettier/recommended',
+  ],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'prettier'],
+  root: true,
+  ignorePatterns: ['dist/'],
+  rules: {
+    '@typescript-eslint/no-inferrable-types': 0,
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
+  },
+}

--- a/packages/http-client/.prettierrc.cjs
+++ b/packages/http-client/.prettierrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  semi: false,
+  trailingComma: 'all',
+  singleQuote: true,
+  quoteProps: 'as-needed',
+  printWidth: 100,
+  tabWidth: 2,
+}

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -1,0 +1,1 @@
+# Docmaps API http client

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@docmaps/http-client",
+  "version": "0.1.0",
+  "description": "HTTP client for Docmaps API specification",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "test": "ava",
+    "clean": "rm -rf dist/",
+    "test:integration": "ava test/integration/",
+    "test:cleanup": "docker compose -f test/integration/assets/docker-compose.yml down",
+    "test:unit": "ava test/unit/",
+    "lint": "npx eslint .",
+    "lint:fix": "npx eslint --fix .",
+    "start": "tsx dist/httpserver/main.js",
+    "prepare": "tsc --declaration",
+    "build": "tsc --declaration"
+  },
+  "keywords": [],
+  "author": "eve github.com/ships",
+  "license": "ISC",
+  "files": [
+    "dist/",
+    "README.md",
+    "package.json",
+    "tsconfig.json"
+  ],
+  "dependencies": {
+    "@ts-rest/core": "^3.30.2",
+    "@tsconfig/node-lts-strictest-esm": "^18.12.1",
+    "docmaps-sdk": "workspace:^0.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.16.2",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.39.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.0.0",
+    "ts-mockito": "^2.6.1",
+    "typescript": "^4.9.5",
+    "zod": "^3.22.2"
+  },
+  "ava": {
+    "extensions": {
+      "ts": "module"
+    },
+    "nodeArguments": [
+      "--loader=ts-node/esm",
+      "--experimental-specifier-resolution=node"
+    ],
+    "files": [
+      "**/*.test.ts"
+    ]
+  },
+  "engines": {
+    "node": ">=18.14.0"
+  }
+}

--- a/packages/http-client/src/client.ts
+++ b/packages/http-client/src/client.ts
@@ -1,0 +1,13 @@
+import { contract } from './contract'
+import { initClient, InitClientArgs } from '@ts-rest/core'
+
+export function MakeHttpClient(opts: InitClientArgs) {
+  return initClient(contract, opts)
+}
+
+const _localClient = MakeHttpClient({
+  baseUrl: 'http://localhost:3000',
+  baseHeaders: {},
+})
+
+export type DocmapsApiClientT = typeof _localClient

--- a/packages/http-client/src/contract.ts
+++ b/packages/http-client/src/contract.ts
@@ -1,0 +1,37 @@
+import { initContract } from '@ts-rest/core'
+import { DocmapT } from 'docmaps-sdk'
+import { ApiInfo } from './types'
+
+const c = initContract()
+
+export const contract = c.router({
+  getInfo: {
+    method: 'GET',
+    path: '/info',
+    responses: {
+      200: c.type<ApiInfo>(),
+    },
+    summary: 'Get information about this Docmaps API server',
+  },
+
+  getDocmapById: {
+    method: 'GET',
+    path: '/docmap/:id',
+    // TODO: id as arg?
+    responses: {
+      200: c.type<DocmapT>(),
+    },
+    summary: 'Get a docmap matching an IRI exactly',
+  },
+
+  getDocmapForDoi: {
+    method: 'GET',
+    path: '/docmap_for/doi',
+    query: c.type<{ subject: string }>(),
+    // TODO: id as arg?
+    responses: {
+      200: c.type<DocmapT>(),
+    },
+    summary: 'Get a docmap that describes a research artifact with this DOI',
+  },
+})

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -1,0 +1,2 @@
+export * from './client'
+export * from './contract'

--- a/packages/http-client/src/types.ts
+++ b/packages/http-client/src/types.ts
@@ -1,0 +1,12 @@
+// TODO: use io-ts? this is only decodable by consumers...
+export type ApiInfo = {
+  api_url: string
+  api_version: string
+  ephemeral_document_expiry: {
+    max_seconds: number
+    max_retrievals: number
+  }
+  peers: {
+    api_url: string
+  }[]
+}

--- a/packages/http-client/tsconfig.json
+++ b/packages/http-client/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "@tsconfig/node-lts-strictest-esm/tsconfig.json",
+  "noErrorTruncation": true,
+  "compilerOptions": {
+    "noErrorTruncation": true,
+    "module": "esnext",
+    "target": "ES2020",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "importsNotUsedAsValues": "remove",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "noUnusedLocals": false,
+    "removeComments": true,
+    "declaration": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.0.0
         version: 6.4.1(eslint@8.40.0)(typescript@4.9.5)
-      ava:
-        specifier: ^5.2.0
-        version: 5.2.0
       eslint:
         specifier: ^8.39.0
         version: 8.40.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,52 @@ importers:
         specifier: ^18.16.2
         version: 18.16.7
 
+  packages/http-client:
+    dependencies:
+      '@ts-rest/core':
+        specifier: ^3.30.2
+        version: 3.30.4(zod@3.22.4)
+      '@tsconfig/node-lts-strictest-esm':
+        specifier: ^18.12.1
+        version: 18.12.1
+      docmaps-sdk:
+        specifier: workspace:^0.0.0
+        version: link:../ts-sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^18.16.2
+        version: 18.16.7
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.0.0
+        version: 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.40.0)(typescript@4.9.5)
+      '@typescript-eslint/parser':
+        specifier: ^6.0.0
+        version: 6.4.1(eslint@8.40.0)(typescript@4.9.5)
+      ava:
+        specifier: ^5.2.0
+        version: 5.2.0
+      eslint:
+        specifier: ^8.39.0
+        version: 8.40.0
+      eslint-config-prettier:
+        specifier: ^9.0.0
+        version: 9.0.0(eslint@8.40.0)
+      eslint-plugin-prettier:
+        specifier: ^5.0.0
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.40.0)(prettier@3.0.2)
+      prettier:
+        specifier: ^3.0.0
+        version: 3.0.2
+      ts-mockito:
+        specifier: ^2.6.1
+        version: 2.6.1
+      typescript:
+        specifier: ^4.9.5
+        version: 4.9.5
+      zod:
+        specifier: ^3.22.2
+        version: 3.22.4
+
   packages/spa:
     dependencies:
       '@docmaps/etl':
@@ -593,11 +639,6 @@ packages:
     dependencies:
       eslint: 8.40.0
       eslint-visitor-keys: 3.4.1
-    dev: true
-
-  /@eslint-community/regexpp@4.5.0:
-    resolution: {integrity: sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
   /@eslint-community/regexpp@4.7.0:
@@ -1388,10 +1429,20 @@ packages:
       '@zazuko/prefixes': 2.0.0
     dev: false
 
+  /@ts-rest/core@3.30.4(zod@3.22.4):
+    resolution: {integrity: sha512-wHI3OHnqpak8jmz2drjzMtgvFVLBrTMvxkkWIUIsGDkEpFwuF/9592RpawkCLIvlxbrxTzp0MzqqwwbzlG6BkA==}
+    peerDependencies:
+      zod: ^3.22.3
+    peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      zod: 3.22.4
+    dev: false
+
   /@tsconfig/node-lts-strictest-esm@18.12.1:
     resolution: {integrity: sha512-LvBLmaC6Q/txTddLc11OeMHF9XjJFzlilkETJuvBlUvHy9pPiMsoH3nxWZM1FMSO53zp4mJP6gzOzxKEq0me7Q==}
     deprecated: TypeScript 5.0 supports combining TSConfigs using array syntax in extends
-    dev: true
 
   /@tsconfig/node10@1.0.9:
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
@@ -2957,7 +3008,7 @@ packages:
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.40.0)
-      '@eslint-community/regexpp': 4.5.0
+      '@eslint-community/regexpp': 4.7.0
       '@eslint/eslintrc': 2.0.3
       '@eslint/js': 8.40.0
       '@humanwhocodes/config-array': 0.11.8
@@ -6457,6 +6508,9 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
   github.com/source-data/render-rev/e77d8a0840fa6a33ea6663aa57dee6ff0930faed(@spider-ui/global-event-registry@0.2.7)(upgraded-element@0.6.5):
     resolution: {tarball: https://codeload.github.com/source-data/render-rev/tar.gz/e77d8a0840fa6a33ea6663aa57dee6ff0930faed}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - 'packages/ts-etl'
   - 'packages/spa'
   - 'packages/example'
+  - 'packages/http-client'


### PR DESCRIPTION
## Description

The http-client package previously lived in https://github.com/Docmaps-Project/ts-api-server/, but that repo is going to be deprecated.

This PR adds it to the monorepo.

### Related Issues

- https://github.com/Docmaps-Project/docmaps/issues/126

### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [X] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Note: there aren't any tests for this module. The tests all live within the ts-api-server `runtime` package. Once we add the runtime package, this code will be tested again.