### PR TITLE
widget: Display nodes as a tree

### DIFF
--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -21,6 +21,7 @@
     "@lit/task": "^1.0.0",
     "d3": "^7.8.5",
     "d3-force": "^3.0.0",
+    "dagre": "^0.8.5",
     "docmaps-sdk": "workspace:^0.0.0",
     "fp-ts": "^2.16.1",
     "lit": "^2.7.6"
@@ -32,6 +33,7 @@
     "@types/d3": "^7.4.2",
     "@types/d3-force": "^3.0.7",
     "@types/d3-selection": "^3.0.8",
+    "@types/dagre": "^0.7.51",
     "@types/node": "^18.16.2",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/packages/widget/src/docmaps-widget.ts
+++ b/packages/widget/src/docmaps-widget.ts
@@ -23,14 +23,14 @@ const GRAPH_CANVAS_ID: string = 'd3-canvas';
 const FIRST_NODE_RADIUS: number = 50;
 const NODE_RADIUS: number = 37.5;
 
-const typeDisplayOpts: {
-  [type: string]: {
-    shortLabel: string;
-    longLabel: string;
-    backgroundColor: string;
-    textColor: string;
-  };
-} = {
+type TypeDisplayOption = {
+  shortLabel: string;
+  longLabel: string;
+  backgroundColor: string;
+  textColor: string;
+};
+
+const typeDisplayOpts: { [type: string]: TypeDisplayOption } = {
   review: {
     shortLabel: 'R',
     longLabel: 'Review',
@@ -99,12 +99,11 @@ export class DocmapsWidget extends LitElement {
   @property({ type: Number })
   count: number = 3;
 
-  #docmapFetchingTask: Task<DocmapFetchingParams, DisplayObjectGraph> =
-    new Task(
-      this,
-      getDocmap,
-      (): DocmapFetchingParams => [this.serverUrl, this.doi],
-    );
+  #docmapFetchingTask: Task<DocmapFetchingParams, DisplayObjectGraph> = new Task(
+    this,
+    getDocmap,
+    (): DocmapFetchingParams => [this.serverUrl, this.doi],
+  );
 
   static styles = [customCss];
 
@@ -139,9 +138,7 @@ export class DocmapsWidget extends LitElement {
       return;
     }
 
-    d3.select(
-      this.shadowRoot.querySelector(`#${GRAPH_CANVAS_ID} svg`),
-    ).remove();
+    d3.select(this.shadowRoot.querySelector(`#${GRAPH_CANVAS_ID} svg`)).remove();
     const canvas = this.shadowRoot.querySelector(`#${GRAPH_CANVAS_ID}`);
     if (!canvas) {
       throw new Error('SVG element not found');
@@ -171,10 +168,7 @@ export class DocmapsWidget extends LitElement {
       .force('collide', d3.forceCollide(FIRST_NODE_RADIUS * 1.5))
       .force(
         'center',
-        d3.forceCenter(
-          Math.floor(WIDGET_SIZE / 2),
-          Math.floor(GRAPH_CANVAS_HEIGHT / 2),
-        ),
+        d3.forceCenter(Math.floor(WIDGET_SIZE / 2), Math.floor(GRAPH_CANVAS_HEIGHT / 2)),
       );
 
     const linkElements = svg
@@ -208,10 +202,6 @@ export class DocmapsWidget extends LitElement {
       .attr('text-anchor', 'middle')
       .attr('dy', '.35em') // Vertically center
       .attr('fill', (d) => typeDisplayOpts[d.type].textColor) // Set the text color
-      .style('font-size', (d, i) => (i === 0 ? '50px' : '30px'))
-      .attr('font-style', 'normal')
-      .attr('font-weight', '600')
-      .attr('font-family', 'IBM Plex Mono; monospace')
       .text((d) => typeDisplayOpts[d.type].shortLabel);
 
     simulation.on('tick', () => {
@@ -230,9 +220,7 @@ export class DocmapsWidget extends LitElement {
     this.setUpTooltips(labels);
   }
 
-  private setUpTooltips(
-    selection: d3.Selection<any, D3Node, SVGGElement, unknown>,
-  ) {
+  private setUpTooltips(selection: d3.Selection<any, D3Node, SVGGElement, unknown>) {
     if (!this.shadowRoot) {
       return;
     }

--- a/packages/widget/src/docmaps-widget.ts
+++ b/packages/widget/src/docmaps-widget.ts
@@ -287,7 +287,6 @@ function getDagreGraph(
   for (const edge of edges) {
     g.setEdge(edge.sourceId, edge.targetId);
   }
-
   Dagre.layout(g);
 
   return g;

--- a/packages/widget/src/docmaps-widget.ts
+++ b/packages/widget/src/docmaps-widget.ts
@@ -200,7 +200,7 @@ export class DocmapsWidget extends LitElement {
       .enter()
       .append('text')
       .attr('text-anchor', 'middle')
-      .attr('dy', '.35em') // Vertically center
+      .attr('dominant-baseline', 'central')
       .attr('fill', (d) => typeDisplayOpts[d.type].textColor) // Set the text color
       .text((d) => typeDisplayOpts[d.type].shortLabel);
 
@@ -212,8 +212,9 @@ export class DocmapsWidget extends LitElement {
         .attr('y2', (d) => (d.target as D3Node).y ?? 0);
 
       nodeElements.attr('cx', getNodeX).attr('cy', getNodeY);
-
-      labels.attr('x', getNodeX).attr('y', getNodeY);
+      labels
+        .attr('x', (d: D3Node) => getNodeX(d) + .8) // We offset slightly because otherwise the label looks very slightly off-center horizontally
+        .attr('y', getNodeY);
     });
 
     this.setUpTooltips(nodeElements);

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -78,12 +78,13 @@ export const customCss: CSSResult = css`
 
   .widget-header span {
     color: white;
+    font-family: 'IBM Plex Mono', 'SF Pro Display', monospace;
     font-size: 12px;
-    font-family: 'SF Pro Display', 'Helvetica Neue', Arial, sans-serif;
+    font-style: normal;
     font-weight: 400;
+    line-height: normal;
+    letter-spacing: 2.4px;
     text-transform: uppercase;
-    letter-spacing: 2.40px;
-    word-wrap: break-word;
   }
 
   .docmap-logo {
@@ -101,6 +102,19 @@ export const customCss: CSSResult = css`
     visibility: hidden;
     opacity: 0;
     transition: opacity 0.3s;
+  }
+
+  .labels text {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 30px; /* This is the default size; it will be overridden by specific styles below */
+    font-style: normal;
+    font-weight: 600;
+    text-anchor: middle;
+    //letter-spacing: 10px;
+    text-transform: uppercase;
+  }
+  .labels text:first-child {
+    font-size: 50px;
   }
 
 `

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -23,9 +23,9 @@ test('The header bar is displayed in the graph view even if the requested docmap
 });
 
 const docmapsToTest: [any, number, string[]][] = [
-  [docmapWithOneStep, 2, ["", "RA"]],
-  [anotherDocmapWithOneStep, 4, ["", "RA", "RA", "RA"]],
-  [docmapWithMultipleSteps, 6, ["P", "P", "RA", "RE", "ES", "RA"]],
+  [docmapWithOneStep, 2, ['', 'RA']],
+  [anotherDocmapWithOneStep, 4, ['', 'RA', 'RA', 'RA']],
+  [docmapWithMultipleSteps, 6, ['P', 'P', 'RA', 'RE', 'ES', 'RA']],
 ];
 
 for (const [docmap, expectedNodes, expectedNodeLabels] of docmapsToTest) {
@@ -49,13 +49,17 @@ for (const [docmap, expectedNodes, expectedNodeLabels] of docmapsToTest) {
     const firstCircle = widget.locator('circle').first();
     const firstCircleBoundingBox = await firstCircle.boundingBox();
     expect(firstCircleBoundingBox).toBeDefined();
-    expect(firstCircleBoundingBox.y).toBe(126);
 
     // assert the last circle is at the y location of 282.25
     const lastCircle = widget.locator('circle').last();
     const lastCircleBoundingBox = await lastCircle.boundingBox();
     expect(lastCircleBoundingBox).toBeDefined();
-    expect(lastCircleBoundingBox.y).toBe(282.25);
+
+    // Assert that lastCircleBoundingBox.y is roughly twice the value of firstCircleBoundingBox.y
+    // Because the first node should appear above the other nodes.
+    // We use this math instead of a fixed value because the exact y values change depending on the browser/platform.
+    expect(lastCircleBoundingBox.y).toBeGreaterThan(firstCircleBoundingBox.y * 1.7);
+    expect(lastCircleBoundingBox.y).toBeLessThan(firstCircleBoundingBox.y * 2.3);
 
     // assert the node labels are in the proper order
     await expect(widget.locator('text')).toHaveCount(expectedNodeLabels.length);

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -17,11 +17,7 @@ test('The header bar is displayed in the graph view even if the requested docmap
   mount,
   context,
 }) => {
-  await mockDocmapForEndpoint(
-    context,
-    'not-the-requested-doi',
-    docmapWithOneStep,
-  );
+  await mockDocmapForEndpoint(context, 'not-the-requested-doi', docmapWithOneStep);
   const widget: Locator = await mount(DocmapsWidget, options);
   await expect(widget.locator('.widget-header')).toContainText('DOCMAP');
 });
@@ -48,25 +44,20 @@ for (const [docmap, expectedNodes] of docmapsToTest) {
     });
 
     await expect(widget.locator('circle')).toHaveCount(expectedNodes);
+
+    // assert the first circle is at the y location of 126
+    const firstCircle = widget.locator('circle').first();
+    const firstCircleBoundingBox = await firstCircle.boundingBox();
+    expect(firstCircleBoundingBox).toBeDefined();
+    expect(firstCircleBoundingBox.y).toBe(126);
+
+    // assert the last circle is at the y location of 282.25
+    const lastCircle = widget.locator('circle').last();
+    const lastCircleBoundingBox = await lastCircle.boundingBox();
+    expect(lastCircleBoundingBox).toBeDefined();
+    expect(lastCircleBoundingBox.y).toBe(282.25);
   });
 }
-
-test('It retrieves a different docmap from the server', async ({
-  mount,
-  context,
-}) => {
-  const doi: string = 'should-return-something';
-  await mockDocmapForEndpoint(context, doi, docmapWithMultipleSteps);
-
-  const widget: Locator = await mount(DocmapsWidget, {
-    props: {
-      ...options.props,
-      doi,
-    },
-  });
-
-  await expect(widget.locator('circle')).toHaveCount(6);
-});
 
 test('Tooltips appear on mouseover', async ({ page, mount, context }) => {
   const docmap = docmapWithMultipleSteps; // Assuming you want to test with this data
@@ -81,11 +72,7 @@ test('Tooltips appear on mouseover', async ({ page, mount, context }) => {
   });
 
   // Replace 'circle' with the correct selector for the nodes in your graph
-  await assertTooltipAppears(
-    widget,
-    widget.locator('circle').first(),
-    'Preprint',
-  );
+  await assertTooltipAppears(widget, widget.locator('circle').first(), 'Preprint');
   await assertTooltipAppears(widget, widget.locator('circle').nth(3), 'Reply');
 });
 
@@ -102,11 +89,7 @@ interface DocmapForResponse {
  * @param doi - The DOI (Document Object Identifier) to look for in the URL.
  * @param docmapToReturn - The docmap object to return in the response.
  */
-async function mockDocmapForEndpoint(
-  context: BrowserContext,
-  doi: string,
-  docmapToReturn: any,
-) {
+async function mockDocmapForEndpoint(context: BrowserContext, doi: string, docmapToReturn: any) {
   const shouldMockPredicate = (url: URL): boolean =>
     url.toString().includes(options.props.serverUrl);
 
@@ -130,11 +113,7 @@ async function mockDocmapForEndpoint(
   await context.route(shouldMockPredicate, mockHandler);
 }
 
-async function assertTooltipAppears(
-  widget: Locator,
-  node: Locator,
-  expectedLabeel: string,
-) {
+async function assertTooltipAppears(widget: Locator, node: Locator, expectedLabeel: string) {
   // Hover over the first node to trigger the tooltip
   await node.hover({ trial: false, force: true });
 
@@ -154,8 +133,6 @@ async function assertTooltipAppears(
   if (tooltipBoundingBox && nodeBoundingBox) {
     // Check if the tooltip is near the node after hovering
     expect(tooltipBoundingBox.x).toBeGreaterThan(nodeBoundingBox.x);
-    expect(tooltipBoundingBox.y).toBeLessThan(
-      nodeBoundingBox.y + nodeBoundingBox.height,
-    );
+    expect(tooltipBoundingBox.y).toBeLessThan(nodeBoundingBox.y + nodeBoundingBox.height);
   }
 }

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -22,13 +22,13 @@ test('The header bar is displayed in the graph view even if the requested docmap
   await expect(widget.locator('.widget-header')).toContainText('DOCMAP');
 });
 
-const docmapsToTest: [any, number][] = [
-  [docmapWithOneStep, 2],
-  [anotherDocmapWithOneStep, 4],
-  [docmapWithMultipleSteps, 6],
+const docmapsToTest: [any, number, string[]][] = [
+  [docmapWithOneStep, 2, ["", "RA"]],
+  [anotherDocmapWithOneStep, 4, ["", "RA", "RA", "RA"]],
+  [docmapWithMultipleSteps, 6, ["P", "P", "RA", "RE", "ES", "RA"]],
 ];
 
-for (const [docmap, expectedNodes] of docmapsToTest) {
+for (const [docmap, expectedNodes, expectedNodeLabels] of docmapsToTest) {
   test(`It retrieves a docmap from the server with ${expectedNodes} nodes`, async ({
     mount,
     context,
@@ -56,6 +56,13 @@ for (const [docmap, expectedNodes] of docmapsToTest) {
     const lastCircleBoundingBox = await lastCircle.boundingBox();
     expect(lastCircleBoundingBox).toBeDefined();
     expect(lastCircleBoundingBox.y).toBe(282.25);
+
+    // assert the node labels are in the proper order
+    await expect(widget.locator('text')).toHaveCount(expectedNodeLabels.length);
+    for (let i = 0; i < expectedNodeLabels.length; i++) {
+      const label = widget.locator('text').nth(i);
+      await expect(label).toHaveText(expectedNodeLabels[i]);
+    }
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       d3-force:
         specifier: ^3.0.0
         version: 3.0.0
+      dagre:
+        specifier: ^0.8.5
+        version: 0.8.5
       docmaps-sdk:
         specifier: workspace:^0.0.0
         version: link:../ts-sdk
@@ -493,6 +496,9 @@ importers:
       '@types/d3-selection':
         specifier: ^3.0.8
         version: 3.0.8
+      '@types/dagre':
+        specifier: ^0.7.51
+        version: 0.7.51
       '@types/node':
         specifier: ^18.16.2
         version: 18.16.7
@@ -2471,6 +2477,10 @@ packages:
       '@types/d3-zoom': 3.0.6
     dev: true
 
+  /@types/dagre@0.7.51:
+    resolution: {integrity: sha512-OJtLXov4mK9wZ4/TkBqUM5OBCpIQvv+sT9FZFnM1Ais5yqHEMnDObGGPYYrQhkLVIKik/bD8o9WWn7YQfPkDlQ==}
+    dev: true
+
   /@types/estree@1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
@@ -4223,6 +4233,13 @@ packages:
       d3-zoom: 3.0.0
     dev: false
 
+  /dagre@0.8.5:
+    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
+    dependencies:
+      graphlib: 2.1.8
+      lodash: 4.17.21
+    dev: false
+
   /dashdash@1.14.1:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
@@ -5375,6 +5392,12 @@ packages:
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
+
+  /graphlib@2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
+    dependencies:
+      lodash: 4.17.21
+    dev: false
 
   /handlebars@4.7.7:
     resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}


### PR DESCRIPTION
## Description

Previously the nodes were displayed as a typical d3 force-layout graph.

Now they're displayed as a proper tree

![Screenshot 2023-11-06 at 3 30 55 PM](https://github.com/Docmaps-Project/docmaps/assets/10427453/4b12e5a3-a777-45ee-b9d4-3035be18e107)

### Related Issues

List any issues that are related to this pull request, such as bug reports or feature requests.

### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [ ] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

There is a slight easing that happens after the graph is first rendered.