### PR TITLE
widget: Add outline to nodes with no type

### DIFF
--- a/packages/widget/index.html
+++ b/packages/widget/index.html
@@ -9,6 +9,6 @@
   <script type='module' src='/src/docmaps-widget.ts'></script>
 </head>
 <body>
-<docmaps-widget serverurl='http://localhost:8080' doi='10.1101/2022.11.08.515698'></docmaps-widget>
+<docmaps-widget serverurl='http://localhost:8080' doi='10.15252/rc.2022616985'></docmaps-widget>
 </body>
 </html>

--- a/packages/widget/src/docmaps-widget.ts
+++ b/packages/widget/src/docmaps-widget.ts
@@ -15,7 +15,7 @@ import {
 import { SimulationNodeDatum } from 'd3-force';
 import * as Dagre from 'dagre';
 
-export type D3Node = SimulationNodeDatum & DisplayObject;
+export type D3Node = SimulationNodeDatum & DisplayObject & { x: number; y: number }; // We override x & y since they're optional in SimulationNodeDatum, but not in our use case
 export type D3Edge = SimulationLinkDatum<D3Node>;
 
 const WIDGET_SIZE: number = 500;
@@ -139,10 +139,13 @@ export class DocmapsWidget extends LitElement {
 
   private drawGraph(nodes: DisplayObject[], edges: DisplayObjectEdge[]) {
     if (!this.shadowRoot) {
+      // We cannot draw a graph if we aren't able to find the place we want to draw it
       return;
     }
 
+    // Delete any graphs we drew before
     d3.select(this.shadowRoot.querySelector(`#${GRAPH_CANVAS_ID} svg`)).remove();
+
     const canvas = this.shadowRoot.querySelector(`#${GRAPH_CANVAS_ID}`);
     if (!canvas) {
       throw new Error('SVG element not found');
@@ -296,8 +299,9 @@ function getDagreGraph(
 }
 
 // Convert the naive "DisplayObject" nodes and edges we get from the Docmap controller
-// into the format that d3 expects.
-// Along the way, we also use Dagre to calculate initial positions for the nodes.
+// into nodes and edges that are ready to render via d3
+//
+// Along the way, we also calculate initial positions for the nodes.
 function prepareGraphForSimulation(
   nodes: DisplayObject[],
   edges: DisplayObjectEdge[],

--- a/packages/widget/src/docmaps-widget.ts
+++ b/packages/widget/src/docmaps-widget.ts
@@ -166,7 +166,7 @@ export class DocmapsWidget extends LitElement {
             // @ts-ignore
             return d.nodeId;
           })
-          .distance(RANK_SEPARATION * 1.7)
+          .distance(RANK_SEPARATION * 1.5)
           .strength(0.2),
       )
       .force('charge', d3.forceManyBody())

--- a/packages/widget/src/docmaps-widget.ts
+++ b/packages/widget/src/docmaps-widget.ts
@@ -30,6 +30,7 @@ type TypeDisplayOption = {
   longLabel: string;
   backgroundColor: string;
   textColor: string;
+  dottedBorder?: boolean;
 };
 
 const typeDisplayOpts: { [type: string]: TypeDisplayOption } = {
@@ -84,8 +85,9 @@ const typeDisplayOpts: { [type: string]: TypeDisplayOption } = {
   '??': {
     shortLabel: '',
     longLabel: 'Type unknown',
-    backgroundColor: '#868f8f',
-    textColor: '#FFF',
+    backgroundColor: '#EFEFEF',
+    textColor: '#FFF', // Doesn't actually matter since there's no text
+    dottedBorder: true,
   },
 };
 
@@ -193,7 +195,16 @@ export class DocmapsWidget extends LitElement {
       .append('circle')
       .attr('class', 'node')
       .attr('fill', (d) => typeDisplayOpts[d.type].backgroundColor)
-      .attr('r', (d, i) => (i === 0 ? FIRST_NODE_RADIUS : NODE_RADIUS));
+      .attr('r', (d: D3Node, i: number): number => (i === 0 ? FIRST_NODE_RADIUS : NODE_RADIUS))
+      .attr('stroke', (d: D3Node): string =>
+        typeDisplayOpts[d.type].dottedBorder ? '#777' : 'none',
+      )
+      .attr('stroke-width', (d: D3Node): string =>
+        typeDisplayOpts[d.type].dottedBorder ? '2px' : 'none',
+      )
+      .attr('stroke-dasharray', (d: D3Node): string =>
+        typeDisplayOpts[d.type].dottedBorder ? '8 4' : 'none',
+      );
 
     const labels = svg
       .append('g')

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -61,6 +61,19 @@ for (const [docmap, expectedNodes, expectedNodeLabels] of docmapsToTest) {
     expect(lastCircleBoundingBox.y).toBeGreaterThan(firstCircleBoundingBox.y * 1.7);
     expect(lastCircleBoundingBox.y).toBeLessThan(firstCircleBoundingBox.y * 2.3);
 
+    // assert the nodes are properly styled
+    await expect(widget.locator('circle')).toHaveCount(expectedNodeLabels.length);
+    for (let i = 0; i < expectedNodeLabels.length; i++) {
+      const node = widget.locator('circle').nth(i);
+      const hasType = !!expectedNodeLabels[i];
+      const expectedStroke: string = hasType ? 'none' : '#777';
+      const expectedStrokeWidth: string = hasType ? 'none' : '2px';
+      const expectedStrokeDasharray: string = hasType ? 'none' : '8 4';
+      await expect(node).toHaveAttribute('stroke', expectedStroke);
+      await expect(node).toHaveAttribute('stroke-width', expectedStrokeWidth);
+      await expect(node).toHaveAttribute('stroke-dasharray', expectedStrokeDasharray);
+    }
+
     // assert the node labels are in the proper order
     await expect(widget.locator('text')).toHaveCount(expectedNodeLabels.length);
     for (let i = 0; i < expectedNodeLabels.length; i++) {


### PR DESCRIPTION
## Description

Nodes without types need to be styled differently since they have no label:

![Screenshot 2023-11-07 at 11 49 08 AM](https://github.com/Docmaps-Project/docmaps/assets/10427453/55951bfd-3f28-432b-848c-5a714f2a8d8a)

### Related Issues

List any issues that are related to this pull request, such as bug reports or feature requests.

### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [ ] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Provide any additional information that might be helpful in understanding this pull request, such as screenshots, links to relevant research, or other context.
