### PR TITLE
Enable logging in http-server

### DIFF
--- a/packages/http-client/src/contract.ts
+++ b/packages/http-client/src/contract.ts
@@ -1,6 +1,6 @@
 import { initContract } from '@ts-rest/core'
 import { DocmapT } from 'docmaps-sdk'
-import { ApiInfo } from './types'
+import { ApiInfo, ErrorBody } from './types'
 
 const c = initContract()
 
@@ -20,6 +20,7 @@ export const contract = c.router({
     // TODO: id as arg?
     responses: {
       200: c.type<DocmapT>(),
+      404: c.type<ErrorBody>(),
     },
     summary: 'Get a docmap matching an IRI exactly',
   },
@@ -31,6 +32,7 @@ export const contract = c.router({
     // TODO: id as arg?
     responses: {
       200: c.type<DocmapT>(),
+      404: c.type<ErrorBody>(),
     },
     summary: 'Get a docmap that describes a research artifact with this DOI',
   },

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client'
 export * from './contract'
+export * from './types'

--- a/packages/http-client/src/types.ts
+++ b/packages/http-client/src/types.ts
@@ -10,3 +10,5 @@ export type ApiInfo = {
     api_url: string
   }[]
 }
+
+export type ErrorBody = { message?: string; data?: object }

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -45,6 +45,8 @@
     "isomorphic-fetch": "^3.0.0",
     "n3": "^1.17.1",
     "oxigraph": "^0.3.19",
+    "pino": "^8.16.1",
+    "pino-http": "^8.5.1",
     "streaming-iterables": "^8.0.0",
     "tsx": "^3.12.7"
   },

--- a/packages/http-server/src/httpserver/command.ts
+++ b/packages/http-server/src/httpserver/command.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from '@commander-js/extra-typings'
 import { API_VERSION } from '../api_version'
 import * as hs from './server'
+import pino from 'pino'
 
 // const stdoutWrite = (str: string) => process.stdout.write(str)
 
@@ -21,6 +22,7 @@ export function MakeCli() {
   const cli = new Command()
 
   const BACKEND_TYPES = ['memory', 'sparql-endpoint']
+  const LOG_LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
 
   cli
     .name('docmaps-api-server')
@@ -32,6 +34,13 @@ export function MakeCli() {
   cli
     .command('start')
     .description('start the server')
+    .addOption(
+      new Option('--logLevel <logLevel>', `the maximum log level to emit to stdout`)
+        .env('DM_LOG_LEVEL')
+        .preset('info')
+        .choices(LOG_LEVELS)
+        .makeOptionMandatory(),
+    )
     .addOption(
       new Option('--backendType <backendType>', `the plugin source name`)
         .env('DM_BACKEND_TYPE')
@@ -108,11 +117,18 @@ export function MakeCli() {
           throw 'specified illegal backendType: choose one of `memory`,`sparql-endpoint`'
       }
 
-      const server = new hs.HttpServer(config)
+      const logger = pino({ name: '@docmaps/http-server', level: options.logLevel }).child({
+        lang: 'ts',
+        api_version: API_VERSION,
+      })
+
+      const server = new hs.HttpServer(config, { logger: logger })
       // Inject logging into the server config:
       //
       // const writer = cli.configureOutput()?.writeOut || stdoutWrite
       // writer(out)
+
+      logger.info('finished setup')
       await server.listen()
     })
 

--- a/packages/http-server/src/httpserver/server.ts
+++ b/packages/http-server/src/httpserver/server.ts
@@ -109,7 +109,7 @@ export class HttpServer {
         if (isLeft(result)) {
           return {
             status: 501, // FIXME: more expressive errors.
-            body: result.left,
+            body: { message: result.left.message },
           }
         }
 
@@ -125,7 +125,7 @@ export class HttpServer {
         if (isLeft(result)) {
           return {
             status: 404, // FIXME: more expressive errors.
-            body: result.left,
+            body: { message: result.left.message },
           }
         }
 

--- a/packages/http-server/src/httpserver/server.ts
+++ b/packages/http-server/src/httpserver/server.ts
@@ -8,6 +8,8 @@ import { OxigraphInmemBackend } from '../adapter/oxigraph_inmem'
 import { SparqlAdapter, SparqlFetchBackend } from '../adapter'
 import { isLeft } from 'fp-ts/lib/Either'
 import { BackendAdapter } from '../types'
+import { Logger } from 'pino'
+import phttp from 'pino-http'
 import cors from 'cors'
 
 export type ServerConfig = {
@@ -30,23 +32,37 @@ export type ServerConfig = {
       }
 }
 
+export interface ServerIO {
+  logger: Logger
+}
+
 // TODO: rename?
 export class HttpServer {
   api: ApiInstance
   app: Application
   server: ServerHttp | ServerHttps // FIXME : support https
   config: ServerConfig
+  io: ServerIO
 
-  constructor(config: ServerConfig) {
+  constructor(config: ServerConfig, io: ServerIO) {
     this.config = config
+    this.io = {
+      ...io,
+    }
 
     let adapter: BackendAdapter
     switch (config.backend.type) {
       case 'memory':
-        adapter = new SparqlAdapter(new OxigraphInmemBackend(config.backend.memory.baseIri))
+        adapter = new SparqlAdapter(
+          new OxigraphInmemBackend(config.backend.memory.baseIri),
+          io.logger,
+        )
         break
       case 'sparqlEndpoint':
-        adapter = new SparqlAdapter(new SparqlFetchBackend(config.backend.sparqlEndpoint.url))
+        adapter = new SparqlAdapter(
+          new SparqlFetchBackend(config.backend.sparqlEndpoint.url),
+          io.logger,
+        )
         break
     }
 
@@ -56,6 +72,21 @@ export class HttpServer {
 
     // TODO Allow CORS to be configured in production
     this.app.use(cors())
+
+    // enable per-request logging
+    this.app.use(
+      phttp({
+        // delegate to parent logger
+        logger: this.io.logger,
+        customLogLevel: (_req, res, err) => {
+          if (res.statusCode >= 400 || err) {
+            return 'info'
+          }
+
+          return 'debug'
+        },
+      }),
+    )
 
     // app.use(bodyParser.urlencoded({ extended: false }))
     // app.use(bodyParser.json())
@@ -89,7 +120,6 @@ export class HttpServer {
       },
       getDocmapForDoi: async (req) => {
         const doi = req.query.subject
-        console.log(doi)
         const result = await this.api.get_docmap_for_thing({ identifier: doi, kind: 'doi' })()
 
         if (isLeft(result)) {
@@ -114,15 +144,16 @@ export class HttpServer {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    createExpressEndpoints(contract, router, this.app)
+    createExpressEndpoints(contract, router, this.app, { logInitialization: false })
     this.server = createHttpServer(this.app)
   }
 
   listen(): Promise<void> {
+    this.io.logger.info('opening listener...')
     return new Promise((res, _rej) => {
       // TODO : set listen timeout handling
       this.server.listen(this.config.server.port, () => {
-        // console.log(`Listening at http://localhost:${config.server.port}`)
+        this.io.logger.info(`Listening at http://localhost:${this.config.server.port}`)
         res()
       })
     })
@@ -132,7 +163,7 @@ export class HttpServer {
     return new Promise((res, _rej) => {
       // TODO : set close timeout handling
       this.server.close(() => {
-        // console.log(`Closing server...`)
+        this.io.logger.info(`Closing server...`)
         res()
       })
     })

--- a/packages/http-server/test/unit/sparql.test.ts
+++ b/packages/http-server/test/unit/sparql.test.ts
@@ -3,11 +3,12 @@ import { SparqlAdapter } from '../../src/adapter'
 import * as E from 'fp-ts/lib/Either'
 import { inspect } from 'util'
 import * as fixtures from '../__fixtures__/docmaps'
+import { testLoggerWithPino } from '../utils'
 
 test('docmapForThing: extracts a realistic docmap from a sparql backend when the steps already exist', async (t) => {
   const backend = fixtures.CreateDatastore()
 
-  const processor = new SparqlAdapter(backend)
+  const processor = new SparqlAdapter(backend, testLoggerWithPino(t.log))
 
   const docmap = await processor.docmapForThing({
     identifier: '10.1101/2022.11.08.515698',
@@ -36,7 +37,7 @@ test('docmapForThing: extracts a realistic docmap from a sparql backend when the
 test('docmapForThing: extracts a realistic docmap from a sparql backend when there are multiple candidates', async (t) => {
   const backend = fixtures.CreateDatastore()
 
-  const processor = new SparqlAdapter(backend)
+  const processor = new SparqlAdapter(backend, testLoggerWithPino(t.log))
 
   const docmap = await processor.docmapForThing({
     identifier: '10.1101/2022.11.08.515698',
@@ -65,7 +66,7 @@ test('docmapForThing: extracts a realistic docmap from a sparql backend when the
 test('docmapForThing: returns a failure case if no docmap can be found for a doi', async (t) => {
   const backend = fixtures.CreateDatastore()
 
-  const processor = new SparqlAdapter(backend)
+  const processor = new SparqlAdapter(backend, testLoggerWithPino(t.log))
 
   const docmap = await processor.docmapForThing({
     identifier: '10.1101/2022.11.08.nonexistent',
@@ -77,13 +78,13 @@ test('docmapForThing: returns a failure case if no docmap can be found for a doi
     return
   }
 
-  t.regex(docmap.left.message, /not found/)
+  t.regex(docmap.left.message, /zero quads/)
 })
 
 test('docmapWithiri: constructs and extracts a realistic docmap from a sparql backend', async (t) => {
   const backend = fixtures.CreateDatastore()
 
-  const processor = new SparqlAdapter(backend)
+  const processor = new SparqlAdapter(backend, testLoggerWithPino(t.log))
 
   const docmap = await processor.docmapWithIri(
     'https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.11.08.515698',

--- a/packages/http-server/test/utils.ts
+++ b/packages/http-server/test/utils.ts
@@ -1,0 +1,12 @@
+import pino, { Logger } from 'pino'
+
+export function testLoggerWithPino(log: (s: string) => void): Logger {
+  return pino(
+    // options
+    {
+      level: 'debug',
+    },
+    // a pino.Destination
+    { write: log },
+  )
+}

--- a/packages/http-server/test/utils.ts
+++ b/packages/http-server/test/utils.ts
@@ -4,7 +4,7 @@ export function testLoggerWithPino(log: (s: string) => void): Logger {
   return pino(
     // options
     {
-      level: 'debug',
+      level: 'trace',
     },
     // a pino.Destination
     { write: log },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,12 @@ importers:
       oxigraph:
         specifier: ^0.3.19
         version: 0.3.20
+      pino:
+        specifier: ^8.16.1
+        version: 8.16.1
+      pino-http:
+        specifier: ^8.5.1
+        version: 8.5.1
       streaming-iterables:
         specifier: ^8.0.0
         version: 8.0.1
@@ -3305,6 +3311,11 @@ packages:
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  /atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
   /ava@5.2.0:
     resolution: {integrity: sha512-W8yxFXJr/P68JP55eMpQIa6AiXhCX3VeuajM8nolyWNExcMDD6rnIWKTjw0B/+GkFHBIaN6Jd0LtcMThcoqVfg==}
     engines: {node: '>=14.19 <15 || >=16.15 <17 || >=18'}
@@ -4963,6 +4974,11 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  /fast-redact@3.3.0:
+    resolution: {integrity: sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==}
+    engines: {node: '>=6'}
+    dev: false
+
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
@@ -6082,24 +6098,10 @@ packages:
       lit-html: 2.8.0
     dev: false
 
-  /lit-html@2.7.4:
-    resolution: {integrity: sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==}
-    dependencies:
-      '@types/trusted-types': 2.0.3
-    dev: false
-
   /lit-html@2.8.0:
     resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
     dependencies:
       '@types/trusted-types': 2.0.3
-    dev: false
-
-  /lit@2.7.5:
-    resolution: {integrity: sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==}
-    dependencies:
-      '@lit/reactive-element': 1.6.2
-      lit-element: 3.3.2
-      lit-html: 2.7.4
     dev: false
 
   /lit@2.8.0:
@@ -6777,6 +6779,11 @@ packages:
     engines: {node: '>=14.7.0', npm: '>=6.14.7'}
     dev: false
 
+  /on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+    dev: false
+
   /on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -7087,6 +7094,43 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /pino-abstract-transport@1.1.0:
+    resolution: {integrity: sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==}
+    dependencies:
+      readable-stream: 4.3.0
+      split2: 4.2.0
+    dev: false
+
+  /pino-http@8.5.1:
+    resolution: {integrity: sha512-T/3d9YHKBYpv/QHjNy73P5BNYYkRrC2/D6CxKMecG4fKFLN+B2iC6LsKYzGRTRV+Ld3fjxFC1ca4TUGbPdzk+Q==}
+    dependencies:
+      get-caller-file: 2.0.5
+      pino: 8.16.1
+      pino-std-serializers: 6.2.2
+      process-warning: 2.3.0
+    dev: false
+
+  /pino-std-serializers@6.2.2:
+    resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
+    dev: false
+
+  /pino@8.16.1:
+    resolution: {integrity: sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==}
+    hasBin: true
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.3.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.1.0
+      pino-std-serializers: 6.2.2
+      process-warning: 2.3.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.4.3
+      sonic-boom: 3.7.0
+      thread-stream: 2.4.1
+    dev: false
+
   /pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
@@ -7180,6 +7224,10 @@ packages:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
     dev: false
 
+  /process-warning@2.3.0:
+    resolution: {integrity: sha512-N6mp1+2jpQr3oCFMz6SeHRGbv6Slb20bRhj4v3xR99HqNToAcOe1MFOp4tytyzOfJn+QtN8Rf7U/h2KAn4kC6g==}
+    dev: false
+
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -7256,6 +7304,10 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  /quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+    dev: false
 
   /quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -7489,6 +7541,11 @@ packages:
     dependencies:
       picomatch: 2.3.1
     dev: true
+
+  /real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+    dev: false
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7749,6 +7806,11 @@ packages:
 
   /safe-identifier@0.4.2:
     resolution: {integrity: sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==}
+    dev: false
+
+  /safe-stable-stringify@2.4.3:
+    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
+    engines: {node: '>=10'}
     dev: false
 
   /safer-buffer@2.1.2:
@@ -8024,6 +8086,12 @@ packages:
     resolution: {integrity: sha512-MqR3fVulhjWuRNSMydnTlweu38UhQ0HXM4buStD/S3mc/BzX3CuM9OmhyQpmtYCvoYdl5ris6TI0ZqH355Ymqg==}
     dev: true
 
+  /sonic-boom@3.7.0:
+    resolution: {integrity: sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==}
+    dependencies:
+      atomic-sleep: 1.0.0
+    dev: false
+
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
@@ -8129,6 +8197,11 @@ packages:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
     dependencies:
       readable-stream: 3.6.2
+    dev: false
+
+  /split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
     dev: false
 
   /split@1.0.1:
@@ -8396,6 +8469,12 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  /thread-stream@2.4.1:
+    resolution: {integrity: sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==}
+    dependencies:
+      real-require: 0.2.0
+    dev: false
 
   /through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -9082,7 +9161,7 @@ packages:
     dependencies:
       '@spider-ui/tooltip': 0.2.7(@spider-ui/global-event-registry@0.2.7)(upgraded-element@0.6.5)
       dompurify: 2.4.5
-      lit: 2.7.5
+      lit: 2.8.0
     transitivePeerDependencies:
       - '@spider-ui/global-event-registry'
       - upgraded-element


### PR DESCRIPTION
## Description

Integrate Pino as a logging solution with convenient injection pathways so that diagnostic log lines can be emitted.

Emits log lines at the highly verbose `trace` level in the SPARQL adapter to improve diagnostics in our staging environment.

Adds a body structure to 404 errors.

### Related Issues

Resolves #149 
Will rely on #115 to be particularly valuable

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [x] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Provide any additional information that might be helpful in understanding this pull request, such as screenshots, links to relevant research, or other context.
