### PR TITLE
Use pre-installed playwritght container for widget-tests

### DIFF
--- a/.github/workflows/widget-tests.yaml
+++ b/.github/workflows/widget-tests.yaml
@@ -59,15 +59,10 @@ jobs:
           cd ${{env.PKG_DIR}}
           pnpm run -r build;
 
-      - name: Install Playwright Browsers
-        run: |
-          cd ${{env.PKG_DIR}}
-          pnpm run install:browsers
-
       - name: Run Playwright tests
         run: |
           cd ${{env.PKG_DIR}}
-          pnpm run test
+          HOME=/root pnpm run test
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/widget-tests.yaml
+++ b/.github/workflows/widget-tests.yaml
@@ -12,6 +12,7 @@ env:
 jobs:
   nodejs_test:
     runs-on: ubuntu-latest
+    container: mcr.microsoft.com/playwright:v1.39.0
 
     timeout-minutes: 20
 


### PR DESCRIPTION
## Description

Following some tip threads, I am trying to speed up tests for the widget by
using a pre-built container that has the matching browsers installed 
for widget test run.

Since docker images can be cached by github actions, this should speed things
up nicely.

### Related Issues


### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Provide any additional information that might be helpful in understanding this pull request, such as screenshots, links to relevant research, or other context.
