### PR TITLE
feat(widget): The buttons in the timeline work

### DIFF
--- a/packages/widget/src/assets/detail-navigation-header.ts
+++ b/packages/widget/src/assets/detail-navigation-header.ts
@@ -35,7 +35,7 @@ const forwardButton = (
     </svg>`;
 };
 
-const makeTimeline = (
+const timeline = (
   allNodes: DisplayObject[],
   selectedNode: DisplayObject,
   updateSelectedNode: (node: DisplayObject) => void,
@@ -84,4 +84,4 @@ export const renderDetailNavigationHeader: (
 ) => svg`
   ${backButton(allNodes, selectedNode, updateSelectedNode)}
   ${forwardButton(allNodes, selectedNode, updateSelectedNode)}
-  ${makeTimeline(allNodes, selectedNode, updateSelectedNode)}`;
+  ${timeline(allNodes, selectedNode, updateSelectedNode)}`;

--- a/packages/widget/src/assets/detail-navigation-header.ts
+++ b/packages/widget/src/assets/detail-navigation-header.ts
@@ -17,7 +17,11 @@ const forwardButton: SVGTemplateResult = svg`
 <!--    <circle cx='24' cy='18' r='3' fill='#474747'/>-->
   </svg>`;
 
-const makeTimeline = (allNodes: DisplayObject[], selectedNode: DisplayObject) => {
+const makeTimeline = (
+  allNodes: DisplayObject[],
+  selectedNode: DisplayObject,
+  updateSelectedNode: (node: DisplayObject) => void,
+) => {
   const width = 368;
   const firstXPosition: number = 6.5;
   const lastXPosition: number = 358.5;
@@ -33,10 +37,12 @@ const makeTimeline = (allNodes: DisplayObject[], selectedNode: DisplayObject) =>
 
     const selectedNodeIndicator =
       node.nodeId === selectedNode.nodeId
-        ? svg`<circle class='selected-node-outline' cx='${x}' cy='6.5' r='5.5' stroke='${color}'/> <path class='selected-node-line' d='M${x} 7L${x} 35' stroke='${color}' stroke-linecap='round'/>`
+        ? svg`
+          <circle class='selected-node-outline' cx='${x}' cy='6.5' r='5.5' stroke='${color}'/> 
+          <path class='selected-node-line' d='M${x} 7L${x} 35' stroke='${color}' stroke-linecap='round'/>`
         : nothing;
     return svg`
-      <circle class='timeline-node' cx='${x}' cy='6.5' r='3.5' fill='${color}'/>
+      <circle class='timeline-node clickable' cx='${x}' cy='6.5' r='3.5' fill='${color}' @click="${() => updateSelectedNode(node)}"/>
       ${selectedNodeIndicator}
     `;
   });
@@ -51,7 +57,8 @@ const makeTimeline = (allNodes: DisplayObject[], selectedNode: DisplayObject) =>
 export const renderDetailNavigationHeader: (
   allNodes: DisplayObject[],
   selectedNode: DisplayObject,
-) => SVGTemplateResult = (allNodes: DisplayObject[], selectedNode: DisplayObject) => svg`
+  updateSelectedNode: (node: DisplayObject) => void,
+) => SVGTemplateResult = (allNodes: DisplayObject[], selectedNode: DisplayObject, updateSelectedNode) => svg`
   ${backButton}
   ${forwardButton}
-  ${makeTimeline(allNodes, selectedNode)}`;
+  ${makeTimeline(allNodes, selectedNode, updateSelectedNode)}`;

--- a/packages/widget/src/assets/detail-navigation-header.ts
+++ b/packages/widget/src/assets/detail-navigation-header.ts
@@ -1,21 +1,39 @@
 import { nothing, svg, SVGTemplateResult } from 'lit';
 import { DisplayObject, TYPE_DISPLAY_OPTIONS } from '../constants';
 
-const backButton: SVGTemplateResult = svg`
-  <svg width='36' height='36' viewBox='0 0 36 36' fill='none' xmlns='http://www.w3.org/2000/svg'>
-    <circle cx='17.5' cy='17.5' r='17' stroke='#474747'/>
-    <path transform='scale(-1,1) translate(-35,0)' d='M22.5 17.134C23.1667 17.5189 23.1667 18.4811 22.5 18.866L10.5 25.7942C9.83333 26.1791 9 25.698 9 24.9282L9 11.0718C9 10.302 9.83333 9.82087 10.5 10.2058L22.5 17.134Z' fill='#474747'/>
-    <path transform='scale(-1,1) translate(-35,0)'  d='M24 10L24 26' stroke='#474747' stroke-width='2' stroke-linecap='round'/>
-<!--    <circle cx='24' cy='18' r='3' fill='#474747'/>-->
-  </svg>`;
+const backButton = (
+  allNodes: DisplayObject[],
+  selectedNode: DisplayObject,
+  updateSelectedNode: (node: DisplayObject) => void,
+) => {
+  const selectedIndex = allNodes.findIndex((node) => node.nodeId === selectedNode.nodeId);
+  const previousIndex = selectedIndex > 0 ? selectedIndex - 1 : allNodes.length - 1;
+  const previousNode = allNodes[previousIndex];
+  return svg`
+    <svg class='docmaps-timeline-back clickable' width='36' height='36' viewBox='0 0 36 36' fill='none' xmlns='http://www.w3.org/2000/svg'
+        @click='${() => updateSelectedNode(previousNode)}'>
+      <circle cx='17.5' cy='17.5' r='17' stroke='#474747'/>
+      <path transform='scale(-1,1) translate(-35,0)' d='M22.5 17.134C23.1667 17.5189 23.1667 18.4811 22.5 18.866L10.5 25.7942C9.83333 26.1791 9 25.698 9 24.9282L9 11.0718C9 10.302 9.83333 9.82087 10.5 10.2058L22.5 17.134Z' fill='#474747'/>
+      <path transform='scale(-1,1) translate(-35,0)'  d='M24 10L24 26' stroke='#474747' stroke-width='2' stroke-linecap='round'/>
+    </svg>`;
+};
 
-const forwardButton: SVGTemplateResult = svg`
-  <svg width='36' height='36' viewBox='0 0 36 36' fill='none' xmlns='http://www.w3.org/2000/svg'>
-    <circle cx='17.5' cy='17.5' r='17' stroke='#474747'/>
-    <path d='M22.5 17.134C23.1667 17.5189 23.1667 18.4811 22.5 18.866L10.5 25.7942C9.83333 26.1791 9 25.698 9 24.9282L9 11.0718C9 10.302 9.83333 9.82087 10.5 10.2058L22.5 17.134Z' fill='#474747'/>
-    <path d='M24 10L24 26' stroke='#474747' stroke-width='2' stroke-linecap='round'/>
-<!--    <circle cx='24' cy='18' r='3' fill='#474747'/>-->
-  </svg>`;
+const forwardButton = (
+  allNodes: DisplayObject[],
+  selectedNode: DisplayObject,
+  updateSelectedNode: (node: DisplayObject) => void,
+) => {
+  const index = allNodes.findIndex((node) => node.nodeId === selectedNode.nodeId);
+  const nextIndex = index < allNodes.length - 1 ? index + 1 : 0;
+  const nextNode = allNodes[nextIndex];
+  return svg`
+    <svg class='docmaps-timeline-forward clickable' width='36' height='36' viewBox='0 0 36 36' fill='none' xmlns='http://www.w3.org/2000/svg'
+        @click='${() => updateSelectedNode(nextNode)}'>
+      <circle cx='17.5' cy='17.5' r='17' stroke='#474747'/>
+      <path d='M22.5 17.134C23.1667 17.5189 23.1667 18.4811 22.5 18.866L10.5 25.7942C9.83333 26.1791 9 25.698 9 24.9282L9 11.0718C9 10.302 9.83333 9.82087 10.5 10.2058L22.5 17.134Z' fill='#474747'/>
+      <path d='M24 10L24 26' stroke='#474747' stroke-width='2' stroke-linecap='round'/>
+    </svg>`;
+};
 
 const makeTimeline = (
   allNodes: DisplayObject[],
@@ -42,7 +60,8 @@ const makeTimeline = (
           <path class='selected-node-line' d='M${x} 7L${x} 35' stroke='${color}' stroke-linecap='round'/>`
         : nothing;
     return svg`
-      <circle class='timeline-node clickable' cx='${x}' cy='6.5' r='3.5' fill='${color}' @click="${() => updateSelectedNode(node)}"/>
+      <circle class='timeline-node clickable' cx='${x}' cy='6.5' r='3.5' fill='${color}'
+        @click='${() => updateSelectedNode(node)}'/>
       ${selectedNodeIndicator}
     `;
   });
@@ -58,7 +77,11 @@ export const renderDetailNavigationHeader: (
   allNodes: DisplayObject[],
   selectedNode: DisplayObject,
   updateSelectedNode: (node: DisplayObject) => void,
-) => SVGTemplateResult = (allNodes: DisplayObject[], selectedNode: DisplayObject, updateSelectedNode) => svg`
-  ${backButton}
-  ${forwardButton}
+) => SVGTemplateResult = (
+  allNodes: DisplayObject[],
+  selectedNode: DisplayObject,
+  updateSelectedNode,
+) => svg`
+  ${backButton(allNodes, selectedNode, updateSelectedNode)}
+  ${forwardButton(allNodes, selectedNode, updateSelectedNode)}
   ${makeTimeline(allNodes, selectedNode, updateSelectedNode)}`;

--- a/packages/widget/src/docmaps-widget.ts
+++ b/packages/widget/src/docmaps-widget.ts
@@ -54,18 +54,17 @@ export class DocmapsWidget extends LitElement {
     if (this.selectedNode) {
       content = this.renderDetailsView(this.selectedNode);
     } else {
-      content = html`
-        <div id='tooltip' class='tooltip' style='opacity:0;'></div>
+      content = html` <div id="tooltip" class="tooltip" style="opacity:0;"></div>
         ${this.#docmapFetchingTask.render({ complete: this.renderDocmap.bind(this) })}`;
     }
 
     return html`
-      <div class='docmaps-widget'>
-        <div class='widget-header'>
+      <div class="docmaps-widget">
+        <div class="widget-header">
           ${logo}
           <span>DOCMAP</span>
         </div>
-        <div id='${GRAPH_CANVAS_ID}'></div>
+        <div id="${GRAPH_CANVAS_ID}"></div>
         ${content}
       </div>
     `;
@@ -99,10 +98,10 @@ export class DocmapsWidget extends LitElement {
     this.setupInteractivity(nodeElements, labels);
   }
 
-  private onNodeClick(node: DisplayObject) {
+  private onNodeClick = (node: DisplayObject) => {
     this.selectedNode = node;
     this.requestUpdate(); // Trigger re-render
-  }
+  };
 
   private createEmptySvgForGraph(
     canvas: Element | null,
@@ -187,7 +186,9 @@ export class DocmapsWidget extends LitElement {
     const textColor = opts.detailTextColor || opts.textColor;
 
     return html`
-      <div class="detail-timeline">${renderDetailNavigationHeader(this.allNodes, selectedNode)}</div>
+      <div class="detail-timeline">
+        ${renderDetailNavigationHeader(this.allNodes, selectedNode, this.onNodeClick)}
+      </div>
 
       <div class="detail-header" style="background: ${backgroundColor};">
         <span style="color: ${textColor};"> ${opts.longLabel} </span>

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -306,6 +306,45 @@ test(`clicking a node in the timeline takes you to that node`, async ({ context,
   await expect(widget.locator('.detail-header')).toContainText('Journal Article');
 });
 
+
+test(`clicking the back button takes you to the previous node`, async ({ context, mount }) => {
+  const docmapName: string = 'fakeDocmapWithTwoLonelyNodes';
+  const widget = await renderWidgetWithDocmap(
+    docmapName,
+    fixtures[docmapName].docmap,
+    context,
+    mount,
+  );
+
+  const secondNode = widget.locator('.node').nth(1);
+  await secondNode.click({ force: true });
+
+  await expect(widget.locator('.detail-header')).toContainText('Review Article');
+
+  const backButton = widget.locator('.docmaps-timeline-back').first();
+  await backButton.click({ force: true });
+  await expect(widget.locator('.detail-header')).toContainText('Preprint');
+});
+
+test(`clicking the forward button takes you to the next node`, async ({ context, mount }) => {
+  const docmapName: string = 'fakeDocmapWithTwoLonelyNodes';
+  const widget = await renderWidgetWithDocmap(
+    docmapName,
+    fixtures[docmapName].docmap,
+    context,
+    mount,
+  );
+
+  const secondNode = widget.locator('.node').nth(4);
+  await secondNode.click({ force: true });
+
+  await expect(widget.locator('.detail-header')).toContainText('Type unknown');
+
+  const backButton = widget.locator('.docmaps-timeline-forward').first();
+  await backButton.click({ force: true });
+  await expect(widget.locator('.detail-header')).toContainText('Journal Article');
+});
+
 test('Nodes that are alone on their y level are fixed to the center of the widget horizontally', async ({
   context,
   mount,

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -287,6 +287,25 @@ timelineTestCases.forEach(([docmapName, nodeToClickIndex]) => {
   });
 });
 
+test(`clicking a node in the timeline takes you to that node`, async ({ context, mount }) => {
+  const docmapName: string = 'fakeDocmapWithTwoLonelyNodes';
+  const widget = await renderWidgetWithDocmap(
+    docmapName,
+    fixtures[docmapName].docmap,
+    context,
+    mount,
+  );
+
+  const firstNode = widget.locator('.node').nth(0);
+  await firstNode.click({ force: true });
+
+  await expect(widget.locator('.detail-header')).toContainText('Preprint');
+
+  const nodeToClick = widget.locator('.timeline-node').nth(5);
+  await nodeToClick.click({ force: true });
+  await expect(widget.locator('.detail-header')).toContainText('Journal Article');
+});
+
 test('Nodes that are alone on their y level are fixed to the center of the widget horizontally', async ({
   context,
   mount,

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -306,7 +306,6 @@ test(`clicking a node in the timeline takes you to that node`, async ({ context,
   await expect(widget.locator('.detail-header')).toContainText('Journal Article');
 });
 
-
 test(`clicking the back button takes you to the previous node`, async ({ context, mount }) => {
   const docmapName: string = 'fakeDocmapWithTwoLonelyNodes';
   const widget = await renderWidgetWithDocmap(
@@ -326,6 +325,28 @@ test(`clicking the back button takes you to the previous node`, async ({ context
   await expect(widget.locator('.detail-header')).toContainText('Preprint');
 });
 
+test(`clicking back from the first node wraps you around to the last node`, async ({
+  context,
+  mount,
+}) => {
+  const docmapName: string = 'fakeDocmapWithTwoLonelyNodes';
+  const widget = await renderWidgetWithDocmap(
+    docmapName,
+    fixtures[docmapName].docmap,
+    context,
+    mount,
+  );
+
+  const firstNode = widget.locator('.node').first();
+  await firstNode.click({ force: true });
+
+  await expect(widget.locator('.detail-header')).toContainText('Preprint');
+
+  const backButton = widget.locator('.docmaps-timeline-back').first();
+  await backButton.click({ force: true });
+  await expect(widget.locator('.detail-header')).toContainText('Journal Article');
+});
+
 test(`clicking the forward button takes you to the next node`, async ({ context, mount }) => {
   const docmapName: string = 'fakeDocmapWithTwoLonelyNodes';
   const widget = await renderWidgetWithDocmap(
@@ -343,6 +364,28 @@ test(`clicking the forward button takes you to the next node`, async ({ context,
   const backButton = widget.locator('.docmaps-timeline-forward').first();
   await backButton.click({ force: true });
   await expect(widget.locator('.detail-header')).toContainText('Journal Article');
+});
+
+test(`clicking the forward button from the last node wraps you around to the first node`, async ({
+  context,
+  mount,
+}) => {
+  const docmapName: string = 'fakeDocmapWithTwoLonelyNodes';
+  const widget = await renderWidgetWithDocmap(
+    docmapName,
+    fixtures[docmapName].docmap,
+    context,
+    mount,
+  );
+
+  const lastNode = widget.locator('.node').last();
+  await lastNode.click({ force: true });
+
+  await expect(widget.locator('.detail-header')).toContainText('Journal Article');
+
+  const backButton = widget.locator('.docmaps-timeline-forward').first();
+  await backButton.click({ force: true });
+  await expect(widget.locator('.detail-header')).toContainText('Preprint');
 });
 
 test('Nodes that are alone on their y level are fixed to the center of the widget horizontally', async ({


### PR DESCRIPTION
## Description

This pull request makes it so you can click the forward and back buttons in the timeline, and so you can click on a node in the timeline to go there.

![Screenshot 2023-11-20 at 3 15 37 PM](https://github.com/Docmaps-Project/docmaps/assets/10427453/6fab2e30-b8f7-4663-a16a-7e0fd0d1ca50)

### Related Issues

#133 

### Checklist

- [X] I have tested these changes locally and they work as expected.
- [X] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [X] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

N/A