### PR TITLE
feat(widget): Make links clickable

### DIFF
--- a/packages/widget/src/detail-view.ts
+++ b/packages/widget/src/detail-view.ts
@@ -35,29 +35,43 @@ export function renderDetailsView(
 }
 
 const createMetadataGrid = (metadataEntries: [string, any][]): HTMLTemplateResult => {
-  const gridItems: HTMLTemplateResult[] = metadataEntries.map((entry, index) =>
-    createGridItem(entry, index),
+  const gridItems: HTMLTemplateResult[] = metadataEntries.map(([key, value], index) =>
+    createGridItem(key, value, index),
   );
   return html` <div class="metadata-grid">${gridItems}</div>`;
 };
 
-const createGridItem = ([key, value]: [string, any], index: number): HTMLTemplateResult => {
-  if (Array.isArray(value)) {
-    const values: any[] = value; // rename since it's actually plural
-    return html`
-      <div
-        class="metadata-grid-item key"
-        style="grid-row-start: ${index + 1}; grid-row-end: ${index + values.length + 1};"
-      >
-        ${key}
-      </div>
-      ${values.map((val) => html` <div class="metadata-grid-item value content">${val}</div>`)}
-    `;
+const createGridItem = (key: string, value: any, index: number): HTMLTemplateResult => {
+  let content: HTMLTemplateResult;
+  if (key === 'url') {
+    content = html` <a
+      href="${value}"
+      target="_blank"
+      class="metadata-grid-item value metadata-link"
+      >${value}</a
+    >`;
+  } else if (key === 'content' && Array.isArray(value)) {
+    content = html`${value.map(
+      (val) =>
+        html` <a
+          href="${val}"
+          target="_blank"
+          class="metadata-grid-item value content metadata-link"
+          >${val}</a
+        >`,
+    )}`;
+  } else if (Array.isArray(value)) {
+    content = html`${value.map(
+      (val) => html` <div class="metadata-grid-item value content">${val}</div>`,
+    )}`;
+  } else {
+    content = html`
+      <div class='metadata-grid-item value'>${value}</div>`;
   }
 
   return html`
     <div class="metadata-grid-item key">${key}</div>
-    <div class="metadata-grid-item value">${value}</div>
+    ${content}
   `;
 };
 

--- a/packages/widget/src/detail-view.ts
+++ b/packages/widget/src/detail-view.ts
@@ -44,21 +44,11 @@ const createMetadataGrid = (metadataEntries: [string, any][]): HTMLTemplateResul
 const createGridItem = (key: string, value: any, index: number): HTMLTemplateResult => {
   let content: HTMLTemplateResult;
   if (key === 'url') {
-    content = html` <a
-      href="${value}"
-      target="_blank"
-      class="metadata-grid-item value metadata-link"
-      >${value}</a
-    >`;
+    content = html` <a href='${value}' target='_blank' class='metadata-grid-item value metadata-link'>${value}</a>`;
   } else if (key === 'content' && Array.isArray(value)) {
     content = html`${value.map(
       (val) =>
-        html` <a
-          href="${val}"
-          target="_blank"
-          class="metadata-grid-item value content metadata-link"
-          >${val}</a
-        >`,
+        html` <a href='${val}' target='_blank' class='metadata-grid-item value content metadata-link'>${val}</a>`,
     )}`;
   } else if (Array.isArray(value)) {
     content = html`${value.map(

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -12,42 +12,8 @@ export const customCss: CSSResult = css`
     text-align: start;
   }
 
-  .logo {
-    height: 6em;
-    padding: 1.5em;
-    will-change: filter;
-    transition: filter 300ms;
-  }
-
-  .logo:hover {
-    filter: drop-shadow(0 0 2em #646cffaa);
-  }
-
-  .logo.lit:hover {
-    filter: drop-shadow(0 0 2em #325cffaa);
-  }
-
-  .card {
-    padding: 2em;
-  }
-
   .clickable {
     cursor: pointer;
-  }
-
-  ::slotted(h1) {
-    font-size: 3.2em;
-    line-height: 1.1;
-  }
-
-  a {
-    font-weight: 500;
-    color: #646cff;
-    text-decoration: inherit;
-  }
-
-  a:hover {
-    color: #747bff;
   }
 
   button {
@@ -167,6 +133,16 @@ export const customCss: CSSResult = css`
     line-height: normal;
     padding-top: 7px;
     padding-bottom: 7px;
+  }
+
+  .metadata-link {
+    color: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .metadata-link:hover {
+    color: #C1C1C1;
   }
 
   .detail-header .close-button {

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -130,14 +130,22 @@ test(`Can display details view for a Preprint with every field`, async ({ page }
   await expect(vals.nth(2)).toContainText('1993-10-');
 
   await expect(keys.nth(3)).toContainText('url');
-  await expect(vals.nth(3)).toContainText('https://example.com/sick-preprint-yo');
+  const urlValue: string = 'https://example.com/sick-preprint-yo';
+  await expect(vals.nth(3)).toContainText(urlValue);
 
   await expect(keys.nth(4)).toContainText('content');
-  await expect(vals.nth(4)).toContainText('https://example.com/fake-journal/article/3003.png');
-  await expect(vals.nth(5)).toContainText('https://example.com/fake-journal/article/3003.heic');
+  const contentUrlPng = 'https://example.com/fake-journal/article/3003.png';
+  await expect(vals.nth(4)).toContainText(contentUrlPng);
+  const contentUrlHeic = 'https://example.com/fake-journal/article/3003.heic';
+  await expect(vals.nth(5)).toContainText(contentUrlHeic);
 
   await expect(keys.nth(5)).toContainText('actors');
   await expect(vals.nth(6)).toContainText('eve, Andrew Edstrom');
+
+  // Check that values for `url` and `content` are actual links
+  await expect(widget.locator(`a[href="${urlValue}"]`)).toHaveCount(1);
+  await expect(widget.locator(`a[href="${contentUrlPng}"]`)).toHaveCount(1);
+  await expect(widget.locator(`a[href="${contentUrlHeic}"]`)).toHaveCount(1);
 
   // Assert the details display can be closed
   await widget.locator('.close-button').click({ force: true });


### PR DESCRIPTION
## Description

You can click links now.

The values in the `url` and `content` metadata fields are assumed to be links.

![Screenshot 2023-11-22 at 11 31 27 AM](https://github.com/Docmaps-Project/docmaps/assets/10427453/39999578-710e-4ca2-b69b-a20bfacd44d6)

and on hover it looks like this:
![Screenshot 2023-11-22 at 11 31 48 AM](https://github.com/Docmaps-Project/docmaps/assets/10427453/535c86e9-a09a-4567-bb4b-08f5f3d47bae)

### Related Issues

This finishes #169

### Checklist

- [X] I have tested these changes locally and they work as expected.
- [X] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [X] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information
None