### PR TITLE
fix(widget): metadata fields with lists as values are displayed properly 

### DIFF
--- a/packages/widget/src/detail-view.ts
+++ b/packages/widget/src/detail-view.ts
@@ -42,27 +42,46 @@ const createMetadataGrid = (metadataEntries: [string, any][]): HTMLTemplateResul
 };
 
 const createGridItem = (key: string, value: any, index: number): HTMLTemplateResult => {
-  let content: HTMLTemplateResult;
+  let keyDisplay: HTMLTemplateResult = html` <div class="metadata-grid-item key">${key}</div>`;
+  if (Array.isArray(value)) {
+    const start = index + 1;
+    const end = index + value.length + 1;
+    keyDisplay = html`
+      <div
+        class='metadata-grid-item key'
+        style='grid-row-start: ${start}; grid-row-end: ${end};'
+      >
+        ${key}
+      </div>`;
+  }
+
+  let valueDisplay: HTMLTemplateResult;
   if (key === 'url') {
-    content = html` <a href='${value}' target='_blank' class='metadata-grid-item value metadata-link'>${value}</a>`;
+    valueDisplay = html` <a
+      href="${value}"
+      target="_blank"
+      class="metadata-grid-item value metadata-link"
+      >${value}</a
+    >`;
   } else if (key === 'content' && Array.isArray(value)) {
-    content = html`${value.map(
+    valueDisplay = html`${value.map(
       (val) =>
-        html` <a href='${val}' target='_blank' class='metadata-grid-item value content metadata-link'>${val}</a>`,
+        html` <a
+          href="${val}"
+          target="_blank"
+          class="metadata-grid-item value content metadata-link"
+          >${val}</a
+        >`,
     )}`;
   } else if (Array.isArray(value)) {
-    content = html`${value.map(
+    valueDisplay = html`${value.map(
       (val) => html` <div class="metadata-grid-item value content">${val}</div>`,
     )}`;
   } else {
-    content = html`
-      <div class='metadata-grid-item value'>${value}</div>`;
+    valueDisplay = html` <div class="metadata-grid-item value">${value}</div>`;
   }
 
-  return html`
-    <div class="metadata-grid-item key">${key}</div>
-    ${content}
-  `;
+  return html` ${keyDisplay} ${valueDisplay} `;
 };
 
 const emptyMetadataMessage = (): HTMLTemplateResult => {

--- a/packages/widget/src/detail-view.ts
+++ b/packages/widget/src/detail-view.ts
@@ -46,18 +46,17 @@ const createGridItem = (key: string, value: any, index: number): HTMLTemplateRes
   if (Array.isArray(value)) {
     const start = index + 1;
     const end = index + value.length + 1;
-    keyDisplay = html`
-      <div
-        class='metadata-grid-item key'
-        style='grid-row-start: ${start}; grid-row-end: ${end};'
-      >
-        ${key}
-      </div>`;
+    keyDisplay = html` <div
+      class="metadata-grid-item key"
+      style="grid-row-start: ${start}; grid-row-end: ${end};"
+    >
+      ${key}
+    </div>`;
   }
 
   let valueDisplay: HTMLTemplateResult;
   if (key === 'url') {
-    valueDisplay = html` <a
+    valueDisplay = html`<a
       href="${value}"
       target="_blank"
       class="metadata-grid-item value metadata-link"

--- a/packages/widget/src/detail-view.ts
+++ b/packages/widget/src/detail-view.ts
@@ -41,46 +41,56 @@ const createMetadataGrid = (metadataEntries: [string, any][]): HTMLTemplateResul
   return html` <div class="metadata-grid">${gridItems}</div>`;
 };
 
-const createGridItem = (key: string, value: any, index: number): HTMLTemplateResult => {
-  let keyDisplay: HTMLTemplateResult = html` <div class="metadata-grid-item key">${key}</div>`;
+function displayMetadataKey(key: string, value: any, index: number): HTMLTemplateResult {
   if (Array.isArray(value)) {
+    // This key has multiple values, so we need to span multiple rows
     const start = index + 1;
     const end = index + value.length + 1;
-    keyDisplay = html` <div
+    return html` <div
       class="metadata-grid-item key"
       style="grid-row-start: ${start}; grid-row-end: ${end};"
     >
       ${key}
     </div>`;
   }
+  return html` <div class="metadata-grid-item key">${key}</div>`;
+}
 
-  let valueDisplay: HTMLTemplateResult;
+function displayMetadataValue(key: string, value: any): HTMLTemplateResult {
   if (key === 'url') {
-    valueDisplay = html`<a
-      href="${value}"
-      target="_blank"
-      class="metadata-grid-item value metadata-link"
-      >${value}</a
-    >`;
-  } else if (key === 'content' && Array.isArray(value)) {
-    valueDisplay = html`${value.map(
+    // display as clickable link
+    return html` <a href="${value}" target="_blank" class="metadata-grid-item value metadata-link">
+      ${value}
+    </a>`;
+  }
+
+  if (key === 'content' && Array.isArray(value)) {
+    // display as list of clickable links
+    return html` ${value.map(
       (val) =>
         html` <a
           href="${val}"
           target="_blank"
           class="metadata-grid-item value content metadata-link"
-          >${val}</a
-        >`,
+        >
+          ${val}
+        </a>`,
     )}`;
-  } else if (Array.isArray(value)) {
-    valueDisplay = html`${value.map(
-      (val) => html` <div class="metadata-grid-item value content">${val}</div>`,
-    )}`;
-  } else {
-    valueDisplay = html` <div class="metadata-grid-item value">${value}</div>`;
   }
 
-  return html` ${keyDisplay} ${valueDisplay} `;
+  if (Array.isArray(value)) {
+    // display as list
+    return html`${value.map(
+      (val) => html` <div class="metadata-grid-item value content">${val}</div>`,
+    )}`;
+  }
+
+  // Display as single value
+  return html` <div class="metadata-grid-item value">${value}</div>`;
+}
+
+const createGridItem = (key: string, value: any, index: number): HTMLTemplateResult => {
+  return html` ${displayMetadataKey(key, value, index)} ${displayMetadataValue(key, value)} `;
 };
 
 const emptyMetadataMessage = (): HTMLTemplateResult => {

--- a/packages/widget/test/integration/docmaps-widget.test.ts
+++ b/packages/widget/test/integration/docmaps-widget.test.ts
@@ -132,20 +132,22 @@ test(`Can display details view for a Preprint with every field`, async ({ page }
   await expect(keys.nth(3)).toContainText('url');
   const urlValue: string = 'https://example.com/sick-preprint-yo';
   await expect(vals.nth(3)).toContainText(urlValue);
+  await expect(widget.locator(`a[href="${urlValue}"]`)).toHaveCount(1);
 
-  await expect(keys.nth(4)).toContainText('content');
+  const contentKeyLocator = keys.nth(4);
+  await expect(contentKeyLocator).toContainText('content');
+  await expect(contentKeyLocator).toHaveAttribute('style', 'grid-row-start: 5; grid-row-end: 7;');
+
   const contentUrlPng = 'https://example.com/fake-journal/article/3003.png';
-  await expect(vals.nth(4)).toContainText(contentUrlPng);
   const contentUrlHeic = 'https://example.com/fake-journal/article/3003.heic';
+  await expect(vals.nth(4)).toContainText(contentUrlPng);
   await expect(vals.nth(5)).toContainText(contentUrlHeic);
+  await expect(widget.locator(`a[href="${contentUrlPng}"]`)).toHaveCount(1);
+  await expect(widget.locator(`a[href="${contentUrlHeic}"]`)).toHaveCount(1);
 
   await expect(keys.nth(5)).toContainText('actors');
   await expect(vals.nth(6)).toContainText('eve, Andrew Edstrom');
 
-  // Check that values for `url` and `content` are actual links
-  await expect(widget.locator(`a[href="${urlValue}"]`)).toHaveCount(1);
-  await expect(widget.locator(`a[href="${contentUrlPng}"]`)).toHaveCount(1);
-  await expect(widget.locator(`a[href="${contentUrlHeic}"]`)).toHaveCount(1);
 
   // Assert the details display can be closed
   await widget.locator('.close-button').click({ force: true });


### PR DESCRIPTION
## Description

[This commit](https://github.com/Docmaps-Project/docmaps/commit/14d63633c39ee701f1d9ce3a693b06ef7cfd3a4a) broke the formatting of metadata values that were lists.

This PR fixes that.

### Related Issues

List any issues that are related to this pull request, such as bug reports or feature requests.

### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [ ] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Provide any additional information that might be helpful in understanding this pull request, such as screenshots, links to relevant research, or other context.
