### PR TITLE
Widget: final round of refactors

### DIFF
--- a/packages/widget/src/detail-navigation-header.ts
+++ b/packages/widget/src/detail-navigation-header.ts
@@ -52,7 +52,7 @@ const timeline = (
   const timelineNodes: SVGTemplateResult[] = allNodes.map((node, i) => {
     const x = getNodeX(i, allNodes.length);
     const displayOpts = TYPE_DISPLAY_OPTIONS[node.type];
-    const color = displayOpts.detailBackgroundColor ?? displayOpts.backgroundColor;
+    const color = displayOpts.detailViewBackgroundColor ?? displayOpts.backgroundColor;
 
     const thisNodeIsSelected: boolean = node.nodeId === selectedNode.nodeId;
     const selectedNodeIndicator: SVGTemplateResult | typeof nothing = thisNodeIsSelected

--- a/packages/widget/src/detail-view.ts
+++ b/packages/widget/src/detail-view.ts
@@ -1,5 +1,10 @@
 import { html, HTMLTemplateResult } from 'lit';
-import { DisplayObject, filterMetadataEntries, TYPE_DISPLAY_OPTIONS } from './util';
+import {
+  DisplayObject,
+  isDisplayObjectMetadataField,
+  normalizeDisplayObject,
+  TYPE_DISPLAY_OPTIONS,
+} from './util';
 import { renderDetailNavigationHeader } from './detail-navigation-header';
 import { closeDetailsButton } from './assets';
 
@@ -10,10 +15,10 @@ export function renderDetailsView(
   closeDetailsView: () => void,
 ) {
   const opts = TYPE_DISPLAY_OPTIONS[selectedNode.type];
-  const metadataEntries: [string, any][] = filterMetadataEntries(selectedNode);
+  const metadataFields: [string, any][] = getMetadataFields(selectedNode);
 
   const metadataBody: HTMLTemplateResult =
-    metadataEntries.length > 0 ? createMetadataGrid(metadataEntries) : emptyMetadataMessage();
+    metadataFields.length > 0 ? createMetadataGrid(metadataFields) : emptyMetadataMessage();
 
   const backgroundColor = opts.detailBackgroundColor || opts.backgroundColor;
   const textColor = opts.detailTextColor || opts.textColor;
@@ -97,4 +102,14 @@ const emptyMetadataMessage = (): HTMLTemplateResult => {
   return html` <div class="metadata-item">
     <div class="metadata-key">no metadata found</div>
   </div>`;
+};
+
+const getMetadataFields = (node: DisplayObject): [string, any][] => {
+  // first put the fields in order:
+  const normalizedNode = normalizeDisplayObject(node);
+
+  // then keep only the fields that should be displayed:
+  return Object.entries(normalizedNode).filter(
+    ([key, value]) => isDisplayObjectMetadataField(key) && value,
+  );
 };

--- a/packages/widget/src/detail-view.ts
+++ b/packages/widget/src/detail-view.ts
@@ -15,13 +15,12 @@ export function renderDetailsView(
   closeDetailsView: () => void,
 ) {
   const opts = TYPE_DISPLAY_OPTIONS[selectedNode.type];
-  const metadataFields: [string, any][] = getMetadataFields(selectedNode);
+  const backgroundColor = opts.detailViewBackgroundColor || opts.backgroundColor;
+  const textColor = opts.detailViewTextColor || opts.textColor;
 
-  const metadataBody: HTMLTemplateResult =
-    metadataFields.length > 0 ? createMetadataGrid(metadataFields) : emptyMetadataMessage();
-
-  const backgroundColor = opts.detailBackgroundColor || opts.backgroundColor;
-  const textColor = opts.detailTextColor || opts.textColor;
+  const fieldsToDisplay: [string, any][] = getMetadataFieldsToDisplay(selectedNode);
+  const detailBody: HTMLTemplateResult =
+    fieldsToDisplay.length > 0 ? createMetadataGrid(fieldsToDisplay) : emptyMetadataMessage();
 
   return html`
     <div class="detail-timeline">
@@ -35,7 +34,7 @@ export function renderDetailsView(
       </div>
     </div>
 
-    <div class="detail-body">${metadataBody}</div>
+    <div class="detail-body">${detailBody}</div>
   `;
 }
 
@@ -104,7 +103,7 @@ const emptyMetadataMessage = (): HTMLTemplateResult => {
   </div>`;
 };
 
-const getMetadataFields = (node: DisplayObject): [string, any][] => {
+const getMetadataFieldsToDisplay = (node: DisplayObject): [string, any][] => {
   // first put the fields in order:
   const normalizedNode = normalizeDisplayObject(node);
 

--- a/packages/widget/src/docmap-controller.ts
+++ b/packages/widget/src/docmap-controller.ts
@@ -144,7 +144,16 @@ function thingToDisplayObject(
   const content = extractContentUrls(thing.content);
   const actors: string = extractActorNames(participants);
 
-  return { nodeId, type: determineDisplayType(type), doi, id, published, url, content, actors };
+  return {
+    nodeId,
+    type: determineDisplayType(type),
+    url: url?.toString(),
+    doi,
+    id,
+    published,
+    content,
+    actors,
+  };
 }
 
 function formatDateIfAvailable(date: Date | string | undefined) {

--- a/packages/widget/src/docmap-controller.ts
+++ b/packages/widget/src/docmap-controller.ts
@@ -4,7 +4,7 @@ import { ActorT, Docmap, DocmapT, ManifestationT, RoleInTimeT, StepT, ThingT } f
 import { pipe } from 'fp-ts/lib/function';
 import * as E from 'fp-ts/lib/Either';
 import {
-  ALL_KNOWN_TYPES,
+  ALL_DISPLAY_OBJECT_TYPES,
   DisplayObject,
   DisplayObjectEdge,
   DisplayObjectGraph,
@@ -157,7 +157,7 @@ function formatDateIfAvailable(date: Date | string | undefined) {
 
 function determineDisplayType(ty: string | string[] | undefined): string {
   const singleType: string = (Array.isArray(ty) ? ty[0] : ty) ?? '??';
-  return ALL_KNOWN_TYPES.includes(singleType) ? singleType : '??';
+  return ALL_DISPLAY_OBJECT_TYPES.includes(singleType) ? singleType : '??';
 }
 
 function extractContentUrls(content: ManifestationT[] | undefined) {

--- a/packages/widget/src/docmap-controller.ts
+++ b/packages/widget/src/docmap-controller.ts
@@ -13,6 +13,19 @@ import {
 
 export type DocmapFetchingParams = [string, string]; // [serverUrl, doi]
 
+interface NodesById {
+  [id: string]: DisplayObject;
+}
+
+interface IdAble {
+  id?: string;
+  doi?: string;
+}
+
+interface NameHaver {
+  name: string;
+}
+
 export const getDocmap: TaskFunction<DocmapFetchingParams, DisplayObjectGraph> = async ([
   serverUrl,
   doi,
@@ -63,15 +76,6 @@ function getOrderedSteps(docmap: DocmapT): StepT[] {
   }
 
   return orderedSteps;
-}
-
-interface NodesById {
-  [id: string]: DisplayObject;
-}
-
-interface IdAble {
-  id?: string;
-  doi?: string;
 }
 
 export function stepsToGraph(steps: StepT[]): DisplayObjectGraph {
@@ -140,7 +144,6 @@ function thingToDisplayObject(
   const content = extractContentUrls(thing.content);
   const actors: string = extractActorNames(participants);
 
-  // The order in which we assign these fields determines the order in which they appear in the UI.
   return { nodeId, type: determineDisplayType(type), doi, id, published, url, content, actors };
 }
 
@@ -161,10 +164,6 @@ function extractContentUrls(content: ManifestationT[] | undefined) {
   return content
     ?.map((manifestation: ManifestationT) => manifestation.url?.toString())
     .filter((url: string | undefined): url is string => url !== undefined);
-}
-
-interface NameHaver {
-  name: string;
 }
 
 function extractActorNames(participants: RoleInTimeT[]) {

--- a/packages/widget/src/graph-view.ts
+++ b/packages/widget/src/graph-view.ts
@@ -17,8 +17,12 @@ import { SimulationNodeDatum } from 'd3-force';
 // D3Nodes represent a node that is being passed to D3's force simulation to be rendered in the graph view.
 // They are a superset of DisplayObjects, with additional fields that are used by D3.
 // Note that we override x & y since they're optional in SimulationNodeDatum, but not in our use case
-type D3Node = SimulationNodeDatum & DisplayObject & { x: number; y: number };
-type D3Edge = SimulationLinkDatum<D3Node>;
+type D3Node = SimulationNodeDatum &
+  DisplayObject & {
+    x: number;
+    y: number;
+  };
+type D3Edge = SimulationLinkDatum<D3Node>; // an edge between two D3Nodes
 type DagreGraph = Dagre.graphlib.Graph<DisplayObject>;
 
 export const displayGraph = (
@@ -185,7 +189,11 @@ function groupNodesByYCoordinate(nodeIds: string[], dagreGraph: DagreGraph): Map
 export function prepareGraphForSimulation(
   nodes: DisplayObject[],
   edges: DisplayObjectEdge[],
-): { d3Edges: D3Edge[]; d3Nodes: D3Node[]; graphWidth: number } {
+): {
+  d3Edges: D3Edge[];
+  d3Nodes: D3Node[];
+  graphWidth: number;
+} {
   // Use Dagre to get initial node positions based on graph layout
   const dagreGraph: DagreGraph = getInitialNodePositions(nodes, edges);
 

--- a/packages/widget/src/graph-view.ts
+++ b/packages/widget/src/graph-view.ts
@@ -1,8 +1,6 @@
 import * as d3 from 'd3';
+import { SimulationLinkDatum } from 'd3';
 import {
-  D3Edge,
-  D3Node,
-  DagreGraph,
   DisplayObject,
   DisplayObjectEdge,
   FIRST_NODE_RADIUS,
@@ -14,6 +12,14 @@ import {
   WIDGET_SIZE,
 } from './util';
 import * as Dagre from 'dagre';
+import { SimulationNodeDatum } from 'd3-force';
+
+// D3Nodes represent a node that is being passed to D3's force simulation to be rendered in the graph view.
+// They are a superset of DisplayObjects, with additional fields that are used by D3.
+// Note that we override x & y since they're optional in SimulationNodeDatum, but not in our use case
+type D3Node = SimulationNodeDatum & DisplayObject & { x: number; y: number };
+type D3Edge = SimulationLinkDatum<D3Node>;
+type DagreGraph = Dagre.graphlib.Graph<DisplayObject>;
 
 export const displayGraph = (
   nodes: DisplayObject[],
@@ -197,7 +203,7 @@ export function prepareGraphForSimulation(
   );
 
   // Transform DisplayObjects into D3Nodes with fixed positions as per Dagre layout
-  const d3Nodes: D3Node[] = transformDisplayObjectsToD3Nodes(dagreGraph, yLevelNodeMap, graphWidth);
+  const d3Nodes: D3Node[] = createD3Nodes(dagreGraph, yLevelNodeMap, graphWidth);
 
   // Transform DisplayObjectEdges into edges that D3 can use
   const d3Edges: D3Edge[] = edges.map(
@@ -207,7 +213,7 @@ export function prepareGraphForSimulation(
   return { d3Nodes, d3Edges, graphWidth };
 }
 
-function transformDisplayObjectsToD3Nodes(
+function createD3Nodes(
   dagreGraph: Dagre.graphlib.Graph<DisplayObject>,
   yLevelNodeMap: Map<number, D3Node[]>,
   graphWidth: number,

--- a/packages/widget/src/util.ts
+++ b/packages/widget/src/util.ts
@@ -10,7 +10,7 @@ export interface DisplayObjectMetadata {
   doi?: string;
   id?: string;
   published?: string;
-  url?: URL;
+  url?: string;
   content?: string[];
   actors?: string;
 }
@@ -30,10 +30,6 @@ const DisplayObjectMetadataPrototype: { [K in DisplayObjectMetadataField]: null 
 
 export function isDisplayObjectMetadataField(key: string): key is DisplayObjectMetadataField {
   return key in DisplayObjectMetadataPrototype;
-}
-
-export function displayObjectMetadataFieldNames(): DisplayObjectMetadataField[] {
-  return Object.keys(DisplayObjectMetadataPrototype) as DisplayObjectMetadataField[];
 }
 
 // DisplayObjects are the widget's internal representation of a node from the graph view.

--- a/packages/widget/src/util.ts
+++ b/packages/widget/src/util.ts
@@ -4,14 +4,91 @@ export const GRAPH_CANVAS_ID: string = 'd3-canvas';
 export const FIRST_NODE_RADIUS: number = 50;
 export const NODE_RADIUS: number = 37.5;
 export const RANK_SEPARATION: number = 100;
+
+// The fields of DisplayObject that are shown in the UI
+export interface DisplayObjectMetadata {
+  doi?: string;
+  id?: string;
+  published?: string;
+  url?: URL;
+  content?: string[];
+  actors?: string;
+}
+
+// The following 3 statements allow us to use FieldsToDisplay both as a type and as something we can
+// check against at runtime. We could also use io-ts for this, but that felt like overkill since this
+// is the only place in the widget where we do something like this.
+export type DisplayObjectMetadataField = keyof DisplayObjectMetadata;
+const DisplayObjectMetadataPrototype: { [K in DisplayObjectMetadataField]: null } = {
+  doi: null,
+  id: null,
+  published: null,
+  url: null,
+  content: null,
+  actors: null,
+};
+
+export function isDisplayObjectMetadataField(key: string): key is DisplayObjectMetadataField {
+  return key in DisplayObjectMetadataPrototype;
+}
+
+export function displayObjectMetadataFieldNames(): DisplayObjectMetadataField[] {
+  return Object.keys(DisplayObjectMetadataPrototype) as DisplayObjectMetadataField[];
+}
+
+// DisplayObjects are the widget's internal representation of a node from the graph view.
+// They roughly correspond to a ThingT in the Docmap spec, but with only the fields that we want to display.
+export interface DisplayObject extends DisplayObjectMetadata {
+  nodeId: string; // Used internally to construct graph relationships, never rendered
+  type: string;
+}
+
+// Returns a new DisplayObject which has no fields set to the value undefined,
+// meaning the new Display Object can be merged with another DisplayObject via destructuring.
+//
+// Also puts the fields in the order in which they should be displayed.
+export function normalizeDisplayObject(displayObject: DisplayObject): DisplayObject {
+  const { nodeId, type, doi, id, published, url, content, actors } = displayObject;
+  return {
+    nodeId,
+    type,
+    ...(doi && { doi }),
+    ...(id && { id }),
+    ...(published && { published }),
+    ...(url && { url }),
+    ...(content && { content }),
+    ...(actors && { actors }),
+  };
+}
+
+export function mergeDisplayObjects(a: DisplayObject | undefined, b: DisplayObject): DisplayObject {
+  return {
+    ...(a && normalizeDisplayObject(a)),
+    ...normalizeDisplayObject(b),
+  };
+}
+
+// DisplayObjectEdges are the widget's internal representation of an edge connecting two DisplayObjects.
+export type DisplayObjectEdge = {
+  sourceId: string;
+  targetId: string;
+};
+
+export type DisplayObjectGraph = {
+  nodes: DisplayObject[];
+  edges: DisplayObjectEdge[];
+};
+
+// The appearance of a DisplayObject in the graph view and in the detail view is determined by its 'type' field.
+// The following constants define the possible values of the 'type' field and the appearance that corresponds with each value.
 export type TypeDisplayOption = {
   shortLabel: string;
   longLabel: string;
   backgroundColor: string;
-  detailBackgroundColor?: string; // if this is not set, backgroundColor will be used
-  detailTextColor?: string; // if this is not set, textColor will be used
   textColor: string;
-  dottedBorder?: boolean;
+  dottedBorder?: boolean; // whether the node should be rendered with a dotted border
+  detailViewBackgroundColor?: string; // if this is not set, backgroundColor will be used
+  detailViewTextColor?: string; // if this is not set, textColor will be used
 };
 
 export const TYPE_DISPLAY_OPTIONS: {
@@ -70,82 +147,10 @@ export const TYPE_DISPLAY_OPTIONS: {
     longLabel: 'Type unknown',
     backgroundColor: '#CDCDCD',
     textColor: '#043945',
-    detailBackgroundColor: '#777',
-    detailTextColor: '#CDCDCD',
+    detailViewBackgroundColor: '#777',
+    detailViewTextColor: '#CDCDCD',
     dottedBorder: true,
   },
 };
 
-export const ALL_KNOWN_TYPES: string[] = Object.keys(TYPE_DISPLAY_OPTIONS);
-
-// The fields of DisplayObject that are shown in the UI
-export interface DisplayObjectMetadata {
-  doi?: string;
-  id?: string;
-  published?: string;
-  url?: URL;
-  content?: string[];
-  actors?: string;
-}
-
-// The following 3 statements allow us to use FieldsToDisplay both as a type and as something we can
-// check against at runtime. We could also use io-ts for this, but that felt like overkill since this
-// is the only place in the widget where we do something like this.
-export type DisplayObjectMetadataField = keyof DisplayObjectMetadata;
-const DisplayObjectMetadataPrototype: { [K in DisplayObjectMetadataField]: null } = {
-  doi: null,
-  id: null,
-  published: null,
-  url: null,
-  content: null,
-  actors: null,
-};
-
-export function isDisplayObjectMetadataField(key: string): key is DisplayObjectMetadataField {
-  return key in DisplayObjectMetadataPrototype;
-}
-
-export function displayObjectMetadataFieldNames(): DisplayObjectMetadataField[] {
-  return Object.keys(DisplayObjectMetadataPrototype) as DisplayObjectMetadataField[];
-}
-
-// DisplayObjects are the widget's internal representation of a node from the graph view.
-// They roughly correspond to a ThingT in the Docmap spec, but with only the fields that we want to display.
-export interface DisplayObject extends DisplayObjectMetadata {
-  nodeId: string; // Used internally to construct graph relationships, never rendered
-  type: string;
-}
-
-// Removes undefined values so the DisplayObject can be merged with another DisplayObject via destructuring
-// and puts the fields in the order in which they should be displayed
-export function normalizeDisplayObject(displayObject: DisplayObject): DisplayObject {
-  const { nodeId, type, doi, id, published, url, content, actors } = displayObject;
-  return {
-    nodeId,
-    type,
-    ...(doi && { doi }),
-    ...(id && { id }),
-    ...(published && { published }),
-    ...(url && { url }),
-    ...(content && { content }),
-    ...(actors && { actors }),
-  };
-}
-
-export function mergeDisplayObjects(a: DisplayObject | undefined, b: DisplayObject): DisplayObject {
-  return {
-    ...(a && normalizeDisplayObject(a)),
-    ...normalizeDisplayObject(b),
-  };
-}
-
-// DisplayObjectEdges are the widget's internal representation of an edge connecting two DisplayObjects.
-export type DisplayObjectEdge = {
-  sourceId: string;
-  targetId: string;
-};
-
-export type DisplayObjectGraph = {
-  nodes: DisplayObject[];
-  edges: DisplayObjectEdge[];
-};
+export const ALL_DISPLAY_OBJECT_TYPES: string[] = Object.keys(TYPE_DISPLAY_OPTIONS);

--- a/packages/widget/src/util.ts
+++ b/packages/widget/src/util.ts
@@ -119,6 +119,29 @@ export interface DisplayObject extends FieldsToDisplay {
   type: string;
 }
 
+export function mergeDisplayObjects(a: DisplayObject | undefined, b: DisplayObject): DisplayObject {
+  return {
+    ...(a && normalizeDisplayObject(a)),
+    ...normalizeDisplayObject(b),
+  };
+}
+
+// This function is used to remove undefined values from a display object, so that we can merge
+// it with another display object using destructuring
+function normalizeDisplayObject(displayObject: DisplayObject): DisplayObject {
+  const { nodeId, type, doi, id, published, url, content, actors } = displayObject;
+  return {
+    nodeId,
+    type,
+    ...(doi && { doi }),
+    ...(id && { id }),
+    ...(published && { published }),
+    ...(url && { url }),
+    ...(content && { content }),
+    ...(actors && { actors }),
+  };
+}
+
 export type DisplayObjectEdge = {
   sourceId: string;
   targetId: string;


### PR DESCRIPTION
## Description

- Extracts a `normalizeDisplayObject()` method that removes undefined values and puts the keys in the desired order. It is used right before nodes are displayed and right before they are merged, so we don't have to worry about accidentally dirtying a DisplayObject in some intermediate operation.
- Extracts a `mergeDisplayObjects(a, b)` so we don't have to remember to normalize the DisplayObjects every time we merge.
- Improve typing of `detail-view.ts` so we don't rely so heavily on `any`
- Moves utilities that were in `util.ts` but only relevant to the graph view or detail view into the files where they really belong.
- Renames some types and constants, and adds some comments documenting types or constants whose purpose might be unclear.
- Renames some methods

### Related Issues

List any issues that are related to this pull request, such as bug reports or feature requests.

### Checklist

- [ ] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [ ] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Provide any additional information that might be helpful in understanding this pull request, such as screenshots, links to relevant research, or other context.
