### PR TITLE
Widget should display the full error message on the sPa

### DIFF
--- a/packages/widget/src/docmap-controller.ts
+++ b/packages/widget/src/docmap-controller.ts
@@ -58,7 +58,11 @@ export function getSteps(docmapPerhaps: unknown): StepT[] {
   const stepsMaybe = pipe(docmapPerhaps, Docmap.decode);
 
   if (E.isLeft(stepsMaybe)) {
-    throw new TypeError(`Could not parse Docmap: ${JSON.stringify(docmapPerhaps)}`);
+    throw new TypeError(
+      `Could not parse Docmap: ${JSON.stringify(docmapPerhaps)}, found error: ${JSON.stringify(
+        stepsMaybe.left,
+      )}`,
+    );
   }
 
   const docmap = stepsMaybe.right;

--- a/packages/widget/test/unit/docmap-controller.test.ts
+++ b/packages/widget/test/unit/docmap-controller.test.ts
@@ -48,9 +48,10 @@ test('getSteps when there are multiple steps', (t) => {
 
 test('getSteps on non-docmaps', (t) => {
   const notADocmap = { this: 'is', some: 'randomly', shaped: ['object'] };
-  const err = t.throws(() => getSteps(notADocmap), { instanceOf: TypeError });
-
-  t.is(err?.message, 'Could not parse Docmap: {"this":"is","some":"randomly","shaped":["object"]}');
+  t.throws(() => getSteps(notADocmap), {
+    instanceOf: TypeError,
+    message: /Could not parse Docmap: {"this":"is","some":"randomly","shaped":\["object"\]}/,
+  });
 });
 
 test('getSteps on docmaps without a first step', (t) => {


### PR DESCRIPTION
## Description

Include the validation error from the SDK in console output from widget when parsing fails

### Related Issues

For diagnostics in #211 

### Checklist

- [x] I have tested these changes locally and they work as expected.
- [x] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [x] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

Possibly we will want to wrap this behavior behind a `debug: true` flag for embedders in the future