### PR TITLE
Fix Docmap Explorer in Firefox

### DIFF
--- a/packages/spa/public/index.html
+++ b/packages/spa/public/index.html
@@ -4,7 +4,7 @@
 	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width,initial-scale=1'>
 
-	<title>Docmaps Demonstration</title>
+	<title>Docmaps Explorer</title>
 
 	<link rel='icon' type='image/png' href='./favicon.png'>
 	<link rel='stylesheet' href='./global.css'>

--- a/packages/spa/src/App.svelte
+++ b/packages/spa/src/App.svelte
@@ -63,11 +63,14 @@
   async function fetchData(doi) {
     requestedDoi = doi;
     key += 1;
-    await configureForDoiString(
-      doi,
-      handleData,
-      handleError,
-    );
+    showContent = true;
+
+    // // Once we've fixed the crossref client, we can uncomment this
+    // await configureForDoiString(
+    //   doi,
+    //   handleData,
+    //   handleError,
+    // );
   }
 
   function displayWidgetWithDocmapLiteral() {
@@ -129,12 +132,13 @@
       show: true, // Always show the widget
       props: { doi: requestedDoi, docmap },
     },
-    {
-      name: 'Crossref Demo',
-      component: CrossrefDemo,
-      show: !providingPlaintextDocmap, // Only show the crossref demo when we're not providing a docmap via plaintext
-      props: { json },
-    },
+    // // Once we've fixed the crossref client, we can uncomment this
+    // {
+    //   name: 'Crossref Demo',
+    //   component: CrossrefDemo,
+    //   show: !providingPlaintextDocmap, // Only show the crossref demo when we're not providing a docmap via plaintext
+    //   props: { json },
+    // },
   ];
 
   $: if (typeof requestedDoi !== 'undefined' && requestedDoi) {
@@ -172,7 +176,7 @@
   {/if}
   <br>
 
-  {#if showContent}
+  {#if requestedDoi || (providingPlaintextDocmap && docmap)}
     {#if !providingPlaintextDocmap}
       <p style='margin-top: 60px;'><i>Showing results for: {requestedDoi}</i></p>
     {/if}

--- a/packages/widget/index.html
+++ b/packages/widget/index.html
@@ -196,7 +196,7 @@
               "outputs": [
                 {
                   "published": "2023-01-23T14:34:45.299Z",
-                  "url": "https://example.com/fake-journal/summary/3000",
+                  "url": "https://example.com/fake-journal/summary/3000"
                 },
                 {
                   "type": "journal-article",

--- a/packages/widget/src/styles.ts
+++ b/packages/widget/src/styles.ts
@@ -207,6 +207,9 @@ export const customCss: CSSResult = css`
     }
 
     .tooltip {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 14px;
+        font-weight: 300;
         background: rgba(0, 0, 0, 0.6);
         color: #fff;
         padding: 4px 8px;


### PR DESCRIPTION
## Description

The docmap explorer wasn't working in Firefox and Safari because a CORS error that only happens in those browsers was causing the tabs not to be displayed. The CORS error happened when fetching data from crossref.

This PR comments out the request to crossref and the crossref tab in the explorer UI. We can bring those back once the CORS issue is fixed.

Other changes in this pr:
- The explorer's page title is now "Docmap Explorer" instead of "Docmap Demonstration"
- Adjust font styling for tooltips

### Related Issues

List any issues that are related to this pull request, such as bug reports or feature requests.

### Checklist

- [X] I have tested these changes locally and they work as expected.
- [ ] I have added or updated tests to cover any new functionality or bug fixes.
- [ ] I have updated the documentation to reflect any changes or additions to the project.
- [X] I have followed the [project's code of conduct](/CODE_OF_CONDUCT.md) and conventions for commit messages.

### Additional Information

